### PR TITLE
feat: add header with global search filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "dependencies": {
         "@tanstack/react-query": "^5.62.9",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "framer-motion": "^11.11.17",
         "lucide-react": "^0.474.0",
         "next": "14.2.15",
         "react": "18.2.0",
+        "react-day-picker": "^9.11.0",
         "react-dom": "18.2.0",
         "recharts": "^2.12.7",
         "tailwind-merge": "^3.3.1",
@@ -54,6 +56,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.5.0",
@@ -2120,6 +2128,22 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4980,6 +5004,27 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.11.0.tgz",
+      "integrity": "sha512-L4FYOaPrr3+AEROeP6IG2mCORZZfxJDkJI2df8mv1jyPrNYeccgmFPZDaHyAuPCBCddQFozkxbikj2NhMEYfDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "^4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   "dependencies": {
     "@tanstack/react-query": "^5.62.9",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "framer-motion": "^11.11.17",
     "lucide-react": "^0.474.0",
     "next": "14.2.15",
     "react": "18.2.0",
+    "react-day-picker": "^9.11.0",
     "react-dom": "18.2.0",
     "recharts": "^2.12.7",
     "tailwind-merge": "^3.3.1",
@@ -22,10 +24,10 @@
     "zustand": "^4.5.5"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.1.0",
     "@types/node": "20.17.10",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
-    "@eslint/eslintrc": "^3.1.0",
     "autoprefixer": "10.4.20",
     "eslint": "8.57.1",
     "eslint-config-next": "14.2.15",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,5 @@
+@import "react-day-picker/dist/style.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -14,6 +16,20 @@
   --muted: #a7adb7;
   --border: #24272e;
   color-scheme: dark;
+}
+
+:root.light {
+  --bg: #f8fafc;
+  --surface: #ffffff;
+  --surface-2: #f1f5f9;
+  --primary: #0f172a;
+  --primary-600: #1e293b;
+  --accent: #2563eb;
+  --success: #16a34a;
+  --text: #0f172a;
+  --muted: #64748b;
+  --border: #d0d7e2;
+  color-scheme: light;
 }
 
 @layer base {
@@ -34,4 +50,23 @@
   .card {
     @apply rounded-2xl border border-border bg-surface shadow-soft;
   }
+}
+
+.rdp {
+  @apply rounded-xl bg-surface p-2 text-text;
+}
+
+.rdp-caption_dropdowns select,
+.rdp-caption_label,
+.rdp-button {
+  @apply text-xs font-medium text-text;
+}
+
+.rdp-day_selected,
+.rdp-day_selected:hover {
+  @apply rounded-full bg-primary text-white;
+}
+
+.rdp-day:hover {
+  @apply rounded-full bg-surface-2 text-text;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 
+import Header from "@/components/Header";
 import { cn } from "@/lib/utils";
 import "./globals.css";
 
@@ -26,22 +27,7 @@ export default function RootLayout({
     <html lang="en" className="bg-bg">
       <body className={cn("min-h-screen bg-bg text-text antialiased", inter.className)}>
         <div className="flex min-h-screen flex-col">
-          <header className="sticky top-0 z-50 border-b border-border/70 bg-surface/80 backdrop-blur">
-            <div className="mx-auto flex h-[72px] w-full max-w-none items-center justify-between px-5">
-              <span className="text-lg font-semibold tracking-tight">Poly</span>
-              <nav className="flex items-center gap-6 text-sm text-muted">
-                <a className="transition hover:text-text" href="#">
-                  Overview
-                </a>
-                <a className="transition hover:text-text" href="#">
-                  Reports
-                </a>
-                <a className="transition hover:text-text" href="#">
-                  Settings
-                </a>
-              </nav>
-            </div>
-          </header>
+          <Header />
           <main className="flex-1">
             <div className="mx-auto w-full max-w-none px-5 py-10">{children}</div>
           </main>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Menu, Moon, Sun, User2 } from "lucide-react";
+
+import SearchBar from "@/components/SearchBar";
+
+const LogoMark = () => (
+  <svg
+    width="28"
+    height="28"
+    viewBox="0 0 28 28"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className="text-primary"
+  >
+    <rect width="28" height="28" rx="8" className="fill-primary/10" />
+    <path
+      d="M8 19.5L12.2 8H15.9L20 19.5H17.2L16.3 17H11.7L10.8 19.5H8ZM12.4 15H15.6L14 10.4H14L12.4 15Z"
+      className="fill-current"
+    />
+  </svg>
+);
+
+const Header = () => {
+  const [theme, setTheme] = useState<"dark" | "light">("dark");
+  const [mounted, setMounted] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const mobileMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setMounted(true);
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem("poly-theme");
+    if (stored === "light" || stored === "dark") {
+      setTheme(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handler = (event: MouseEvent) => {
+      if (!mobileMenuRef.current?.contains(event.target as Node)) {
+        setMobileOpen(false);
+      }
+    };
+
+    if (mobileOpen) {
+      document.addEventListener("click", handler);
+    }
+
+    return () => {
+      document.removeEventListener("click", handler);
+    };
+  }, [mobileOpen]);
+
+  useEffect(() => {
+    if (!mounted || typeof document === "undefined") return;
+    document.documentElement.classList.toggle("light", theme === "light");
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    window.localStorage.setItem("poly-theme", theme);
+  }, [theme, mounted]);
+
+  useEffect(() => {
+    if (!advancedOpen) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setAdvancedOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [advancedOpen]);
+
+  const toggleTheme = () => {
+    setTheme((current) => (current === "dark" ? "light" : "dark"));
+  };
+
+  const handleAdvancedClick = () => {
+    setAdvancedOpen(true);
+    setMobileOpen(false);
+  };
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-border/70 bg-surface/80 backdrop-blur">
+      <div className="mx-auto flex h-[72px] w-full max-w-none items-center gap-4 px-5">
+        <div className="flex items-center gap-3">
+          <LogoMark />
+          <span className="text-sm font-semibold tracking-wide text-text/80">Poly Broadcast</span>
+        </div>
+
+        <div className="flex-1">
+          <SearchBar onAdvancedClick={handleAdvancedClick} />
+        </div>
+
+        <div className="hidden items-center gap-3 md:flex">
+          <button
+            type="button"
+            aria-label="Toggle theme"
+            onClick={toggleTheme}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/70 bg-surface-2 text-muted transition hover:border-border hover:text-text"
+          >
+            {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+          </button>
+          <div className="flex h-10 w-10 items-center justify-center rounded-full border border-border/70 bg-surface-2 text-muted">
+            <User2 className="h-4 w-4" />
+          </div>
+        </div>
+
+        <div className="relative md:hidden" ref={mobileMenuRef}>
+          <button
+            type="button"
+            aria-label="Open actions"
+            onClick={(event) => {
+              event.stopPropagation();
+              setMobileOpen((openState) => !openState);
+            }}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/70 bg-surface-2 text-muted transition hover:border-border hover:text-text"
+          >
+            <Menu className="h-4 w-4" />
+          </button>
+          {mobileOpen ? (
+            <div
+              className="absolute right-0 top-12 w-48 rounded-2xl border border-border/70 bg-surface-2 p-3 shadow-soft"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <button
+                type="button"
+                className="flex w-full items-center justify-between rounded-xl px-3 py-2 text-sm text-muted transition hover:bg-surface"
+                onClick={() => {
+                  toggleTheme();
+                  setMobileOpen(false);
+                }}
+              >
+                Theme
+                <span className="inline-flex items-center gap-2 text-xs">
+                  {theme === "dark" ? (
+                    <>
+                      <Sun className="h-4 w-4" />
+                      Light
+                    </>
+                  ) : (
+                    <>
+                      <Moon className="h-4 w-4" />
+                      Dark
+                    </>
+                  )}
+                </span>
+              </button>
+              <div className="mt-2 flex items-center gap-3 rounded-xl border border-border/70 bg-surface px-3 py-2 text-sm text-muted">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full border border-border/60 bg-surface-2">
+                  <User2 className="h-4 w-4" />
+                </div>
+                <div>
+                  <p className="text-xs font-medium text-text">Alex Doe</p>
+                  <p className="text-[11px] text-muted">Product Ops</p>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+      {advancedOpen ? (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          onClick={() => setAdvancedOpen(false)}
+        >
+          <div
+            className="w-[min(90%,420px)] rounded-2xl border border-border/70 bg-surface-2 p-6 text-sm text-muted shadow-soft"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-text">Advanced filters</h2>
+              <button
+                type="button"
+                className="rounded-full border border-border/70 px-3 py-1 text-xs font-medium text-muted transition hover:border-border hover:text-text"
+                onClick={() => setAdvancedOpen(false)}
+              >
+                Close
+              </button>
+            </div>
+            <p className="mt-4 text-xs leading-relaxed text-muted">
+              Configure advanced filters, saved views, and cross-network search boosters here soon.
+            </p>
+          </div>
+        </div>
+      ) : null}
+    </header>
+  );
+};
+
+export default Header;

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { CalendarIcon, Loader2, Search, SlidersHorizontal } from "lucide-react";
+import { DateRange, DayPicker } from "react-day-picker";
+
+import { cn } from "@/lib/utils";
+import useGlobalFilters, {
+  DatasetKey,
+  GlobalFiltersState,
+  formatDateKey,
+  parseDateKey,
+  twitterEnabled,
+} from "@/stores/useGlobalFilters";
+
+type SearchBarProps = {
+  isLoading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+  onAdvancedClick?: () => void;
+  onFiltersChange?: (state: GlobalFiltersState) => void;
+};
+
+type PresetOption = {
+  label: string;
+  value: "7D" | "30D" | "90D" | "custom";
+  days?: number;
+};
+
+const PRESETS: PresetOption[] = [
+  { label: "7D", value: "7D", days: 7 },
+  { label: "30D", value: "30D", days: 30 },
+  { label: "90D", value: "90D", days: 90 },
+  { label: "Custom", value: "custom" },
+];
+
+const msInDay = 1000 * 60 * 60 * 24;
+
+const isSameDay = (a: Date, b: Date) => a.toDateString() === b.toDateString();
+
+const clampToStartOfDay = (date: Date) => {
+  const copy = new Date(date);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+};
+
+const getPresetFromRange = (start: string, end: string): PresetOption["value"] => {
+  const startDate = clampToStartOfDay(parseDateKey(start));
+  const endDate = clampToStartOfDay(parseDateKey(end));
+  const today = clampToStartOfDay(new Date());
+  const diff = Math.round((endDate.getTime() - startDate.getTime()) / msInDay) + 1;
+
+  if (isSameDay(endDate, today)) {
+    if (diff === 7) return "7D";
+    if (diff === 30) return "30D";
+    if (diff === 90) return "90D";
+  }
+
+  return "custom";
+};
+
+const datasetLabels: Record<DatasetKey, string> = {
+  gdelt: "GDELT",
+  poly: "Polymarket",
+  twitter: "Twitter",
+};
+
+const DateRangePopover = ({
+  open,
+  initialRange,
+  onApply,
+  onOpenChange,
+}: {
+  open: boolean;
+  initialRange: DateRange | undefined;
+  onApply: (range: DateRange | undefined) => void;
+  onOpenChange: (next: boolean) => void;
+}) => {
+  const [range, setRange] = useState<DateRange | undefined>(initialRange);
+
+  useEffect(() => {
+    setRange(initialRange);
+  }, [initialRange]);
+
+  if (!open) return null;
+
+  return (
+    <div className="absolute left-0 top-full z-50 mt-2 w-[320px] rounded-2xl border border-border/80 bg-surface-2 p-4 shadow-soft">
+      <DayPicker
+        mode="range"
+        defaultMonth={initialRange?.from}
+        selected={range}
+        onSelect={setRange}
+        numberOfMonths={1}
+        weekStartsOn={1}
+        className="rdp text-sm"
+        captionLayout="dropdown-buttons"
+      />
+      <div className="mt-4 flex justify-end gap-2">
+        <button
+          type="button"
+          className="rounded-lg px-3 py-2 text-sm text-muted transition hover:text-text"
+          onClick={() => {
+            onOpenChange(false);
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="rounded-lg bg-primary px-3 py-2 text-sm font-medium text-white transition hover:bg-primary-600"
+          onClick={() => {
+            onApply(range);
+            onOpenChange(false);
+          }}
+        >
+          Apply
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const SearchBar = ({
+  isLoading,
+  error,
+  onRetry,
+  onAdvancedClick,
+  onFiltersChange,
+}: SearchBarProps) => {
+  const {
+    keywords,
+    dateStart,
+    dateEnd,
+    datasets,
+    setKeywords,
+    setDateRange,
+    toggleDataset,
+  } = useGlobalFilters();
+
+  const [inputValue, setInputValue] = useState(() => keywords.join(" "));
+  const [selectedPreset, setSelectedPreset] = useState<PresetOption["value"]>(() =>
+    getPresetFromRange(dateStart, dateEnd),
+  );
+  const [customOpen, setCustomOpen] = useState(false);
+  const customPresetRef = useRef<HTMLDivElement>(null);
+
+  const initialCustomRange = useMemo<DateRange | undefined>(() => {
+    if (!dateStart || !dateEnd) return undefined;
+    return {
+      from: parseDateKey(dateStart),
+      to: parseDateKey(dateEnd),
+    };
+  }, [dateStart, dateEnd]);
+
+  useEffect(() => {
+    if (!onFiltersChange) return;
+    const unsubscribe = useGlobalFilters.subscribe((state) => {
+      onFiltersChange(state);
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, [onFiltersChange]);
+
+  useEffect(() => {
+    const text = keywords.join(" ");
+    setInputValue((prev) => (prev === text ? prev : text));
+  }, [keywords]);
+
+  useEffect(() => {
+    setSelectedPreset(getPresetFromRange(dateStart, dateEnd));
+  }, [dateStart, dateEnd]);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      const tokens = inputValue
+        .split(/[\s,]+/)
+        .map((token) => token.trim())
+        .filter(Boolean);
+      setKeywords(tokens);
+    }, 300);
+
+    return () => clearTimeout(handle);
+  }, [inputValue, setKeywords]);
+
+  const handlePreset = useCallback(
+    (preset: PresetOption) => {
+      if (preset.value === "custom") {
+        setCustomOpen((openState) => !openState);
+        setSelectedPreset("custom");
+        return;
+      }
+
+      if (!preset.days) return;
+      const end = clampToStartOfDay(new Date());
+      const start = new Date(end);
+      start.setDate(start.getDate() - (preset.days - 1));
+
+      setDateRange(formatDateKey(start), formatDateKey(end));
+      setSelectedPreset(preset.value);
+      setCustomOpen(false);
+    },
+    [setDateRange],
+  );
+
+  const handleApplyCustom = useCallback(
+    (range: DateRange | undefined) => {
+      if (!range?.from || !range?.to) return;
+      const from = clampToStartOfDay(range.from);
+      const to = clampToStartOfDay(range.to);
+      setDateRange(formatDateKey(from), formatDateKey(to));
+    },
+    [setDateRange],
+  );
+
+  const handleDatasetToggle = useCallback(
+    (dataset: DatasetKey) => {
+      if (dataset === "twitter" && !twitterEnabled) return;
+      toggleDataset(dataset);
+    },
+    [toggleDataset],
+  );
+
+  const datasetOptions = useMemo(
+    () =>
+      (["gdelt", "poly", "twitter"] as DatasetKey[]).map((key) => ({
+        key,
+        label: datasetLabels[key],
+        disabled: key === "twitter" && !twitterEnabled,
+        active: datasets[key],
+      })),
+    [datasets],
+  );
+
+  useEffect(() => {
+    if (!customOpen) return;
+    const handler = (event: MouseEvent) => {
+      if (!customPresetRef.current?.contains(event.target as Node)) {
+        setCustomOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [customOpen]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <div className="flex h-12 w-full items-center gap-3 rounded-2xl border border-border/70 bg-surface-2 px-4">
+          <Loader2 className="h-4 w-4 animate-spin text-muted" />
+          <div className="h-3 flex-1 rounded-full bg-border/80" />
+        </div>
+        <div className="h-9 w-full rounded-2xl bg-surface-2" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full space-y-3">
+      {error ? (
+        <div className="flex items-center justify-between rounded-xl border border-primary/50 bg-primary/10 px-4 py-3 text-sm text-primary">
+          <span>{error}</span>
+          {onRetry ? (
+            <button
+              type="button"
+              className="rounded-lg border border-primary/40 px-3 py-1 text-xs font-medium text-primary transition hover:bg-primary/10"
+              onClick={onRetry}
+            >
+              Retry
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="relative flex w-full items-center gap-3 rounded-2xl border border-border/70 bg-surface-2 px-4 py-3 shadow-soft">
+        <Search className="h-4 w-4 flex-none text-muted" />
+        <input
+          className="h-full w-full bg-transparent text-sm text-text placeholder:text-muted focus:outline-none"
+          placeholder="Search events or markets"
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+        />
+        <button
+          type="button"
+          className="hidden items-center gap-2 rounded-xl border border-border/60 px-3 py-2 text-xs font-medium text-muted transition hover:border-border hover:text-text md:inline-flex"
+          onClick={onAdvancedClick}
+        >
+          <SlidersHorizontal className="h-4 w-4" />
+          Advanced
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-wrap items-center gap-2">
+          {PRESETS.map((preset) => (
+            <div
+              key={preset.value}
+              className="relative"
+              ref={preset.value === "custom" ? customPresetRef : undefined}
+            >
+              <button
+                type="button"
+                onClick={() => handlePreset(preset)}
+                className={cn(
+                  "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition",
+                  selectedPreset === preset.value
+                    ? "border-primary/60 bg-primary/10 text-primary"
+                    : "border-border/70 bg-surface text-muted hover:border-border hover:text-text",
+                )}
+              >
+                {preset.value === "custom" ? <CalendarIcon className="h-3.5 w-3.5" /> : null}
+                {preset.label}
+              </button>
+              {preset.value === "custom" ? (
+                <DateRangePopover
+                  open={customOpen}
+                  initialRange={initialCustomRange}
+                  onApply={handleApplyCustom}
+                  onOpenChange={setCustomOpen}
+                />
+              ) : null}
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          {datasetOptions.map((option) => (
+            <button
+              key={option.key}
+              type="button"
+              onClick={() => handleDatasetToggle(option.key)}
+              disabled={option.disabled}
+              className={cn(
+                "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition",
+                option.disabled
+                  ? "cursor-not-allowed border-border/50 text-muted/50"
+                  : option.active
+                    ? "border-primary/60 bg-primary/10 text-primary"
+                    : "border-border/70 bg-surface text-muted hover:border-border hover:text-text",
+              )}
+            >
+              <span>{option.label}</span>
+              {option.disabled ? <span className="text-[10px] uppercase text-muted/60">Off</span> : null}
+            </button>
+          ))}
+
+          <button
+            type="button"
+            className="inline-flex items-center gap-2 rounded-full border border-border/70 px-3 py-1.5 text-xs font-medium text-muted transition hover:border-border hover:text-text md:hidden"
+            onClick={onAdvancedClick}
+          >
+            <SlidersHorizontal className="h-3.5 w-3.5" />
+            Advanced
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SearchBar;

--- a/src/stores/useGlobalFilters.ts
+++ b/src/stores/useGlobalFilters.ts
@@ -1,0 +1,76 @@
+import { create } from "zustand";
+
+type DatasetKey = "gdelt" | "poly" | "twitter";
+
+type GlobalFiltersState = {
+  keywords: string[];
+  dateStart: string;
+  dateEnd: string;
+  datasets: Record<DatasetKey, boolean>;
+  setKeywords: (keywords: string[]) => void;
+  setDateRange: (start: string, end: string) => void;
+  toggleDataset: (dataset: DatasetKey) => void;
+};
+
+const twitterEnabled =
+  typeof process !== "undefined"
+    ? process.env.NEXT_PUBLIC_TWITTER_ENABLED !== "false"
+    : true;
+
+const formatDateKey = (date: Date) => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}${month}${day}`;
+};
+
+const parseDateKey = (value: string) => {
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(4, 6)) - 1;
+  const day = Number(value.slice(6, 8));
+  return new Date(year, month, day);
+};
+
+const today = new Date();
+const defaultStart = new Date(today);
+defaultStart.setDate(defaultStart.getDate() - 6);
+
+type GlobalFiltersStore = GlobalFiltersState & {
+  setKeywords: (keywords: string[]) => void;
+  setDateRange: (start: string, end: string) => void;
+  toggleDataset: (dataset: DatasetKey) => void;
+};
+
+const useGlobalFilters = create<GlobalFiltersStore>((set) => ({
+  keywords: [],
+  dateStart: formatDateKey(defaultStart),
+  dateEnd: formatDateKey(today),
+  datasets: {
+    gdelt: true,
+    poly: true,
+    twitter: twitterEnabled,
+  },
+  setKeywords: (keywords) => set({ keywords }),
+  setDateRange: (dateStart, dateEnd) => set({ dateStart, dateEnd }),
+  toggleDataset: (dataset) =>
+    set((state) => {
+      if (dataset === "twitter" && !twitterEnabled) {
+        return state;
+      }
+
+      return {
+        datasets: {
+          ...state.datasets,
+          [dataset]: !state.datasets[dataset],
+        },
+      };
+    }),
+}));
+
+const subscribeToGlobalFilters = (
+  listener: (state: GlobalFiltersState) => void,
+) => useGlobalFilters.subscribe((state) => listener(state));
+
+export type { GlobalFiltersState, DatasetKey };
+export { formatDateKey, parseDateKey, subscribeToGlobalFilters, twitterEnabled };
+export default useGlobalFilters;


### PR DESCRIPTION
## Summary
- add a sticky header with responsive mobile actions, theme toggle, and advanced modal placeholder
- implement a debounced search bar with date presets, custom range picker, dataset toggles, and loading/error states
- introduce a global filters store and supporting styling updates for light theme and day-picker visuals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd74fc352c8328a127e055849b1611