### PR TITLE
Add sticky top bar search experience

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,7 +13,21 @@
   --text: #eaecee;
   --muted: #a7adb7;
   --border: #24272e;
+  --header-h: 72px;
+  --topbar-gap: 20px;
   color-scheme: dark;
+}
+
+@media (max-width: 1023px) {
+  :root {
+    --topbar-gap: 16px;
+  }
+}
+
+@media (max-width: 767px) {
+  :root {
+    --topbar-gap: 12px;
+  }
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 
 import { cn } from "@/lib/utils";
 import "./globals.css";
+import TopBar from "@/components/TopBar";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -42,8 +43,9 @@ export default function RootLayout({
               </nav>
             </div>
           </header>
-          <main className="flex-1">
-            <div className="mx-auto w-full max-w-none px-5 py-10">{children}</div>
+          <TopBar />
+          <main className="mx-auto w-full max-w-[1440px] flex-1 px-5 pb-10 pt-[var(--topbar-gap)]">
+            {children}
           </main>
           <footer className="border-t border-border/70 bg-surface/60">
             <div className="mx-auto flex h-16 w-full max-w-none items-center justify-between px-5 text-xs text-muted">

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { cn } from "@/lib/utils";
+import { useGlobalFilters, twitterDatasetEnabled } from "@/stores/useGlobalFilters";
+
+type SearchBarProps = {
+  loading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+};
+
+const debounceDelay = 300;
+
+function formatDate(date: Date) {
+  return date.toISOString().slice(0, 10).replaceAll("-", "");
+}
+
+function formatDateForInput(value: string) {
+  if (value.length !== 8) {
+    return "";
+  }
+
+  const year = value.slice(0, 4);
+  const month = value.slice(4, 6);
+  const day = value.slice(6, 8);
+  return `${year}-${month}-${day}`;
+}
+
+function parseDateFromInput(value: string) {
+  return value.replaceAll("-", "");
+}
+
+function getPresetRange(days: number) {
+  const now = new Date();
+  const end = formatDate(now);
+  const startDate = new Date(now);
+  startDate.setDate(now.getDate() - (days - 1));
+  const start = formatDate(startDate);
+  return { start, end };
+}
+
+const datePresets = [
+  { label: "7D", range: () => getPresetRange(7) },
+  { label: "30D", range: () => getPresetRange(30) },
+  { label: "90D", range: () => getPresetRange(90) },
+] as const;
+
+export default function SearchBar({ loading = false, error = null, onRetry }: SearchBarProps) {
+  const keywords = useGlobalFilters((state) => state.keywords);
+  const dateStart = useGlobalFilters((state) => state.dateStart);
+  const dateEnd = useGlobalFilters((state) => state.dateEnd);
+  const datasets = useGlobalFilters((state) => state.datasets);
+  const setKeywords = useGlobalFilters((state) => state.setKeywords);
+  const setDateRange = useGlobalFilters((state) => state.setDateRange);
+  const toggleDataset = useGlobalFilters((state) => state.toggleDataset);
+
+  const [query, setQuery] = useState(() => keywords.join(" "));
+  const [isCustomOpen, setIsCustomOpen] = useState(false);
+  const [customStart, setCustomStart] = useState(dateStart);
+  const [customEnd, setCustomEnd] = useState(dateEnd);
+  const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
+
+  useEffect(() => {
+    setQuery(keywords.join(" "));
+  }, [keywords]);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      const parsed = query
+        .split(/[\s,]+/)
+        .map((value) => value.trim())
+        .filter(Boolean);
+
+      const sameLength = parsed.length === keywords.length;
+      const sameValues = sameLength && parsed.every((value, index) => value === keywords[index]);
+
+      if (!sameValues) {
+        setKeywords(parsed);
+      }
+    }, debounceDelay);
+
+    return () => clearTimeout(handle);
+  }, [query, keywords, setKeywords]);
+
+  useEffect(() => {
+    if (!isCustomOpen) {
+      setCustomStart(dateStart);
+      setCustomEnd(dateEnd);
+    }
+  }, [dateEnd, dateStart, isCustomOpen]);
+
+  const isCustomRangeActive = useMemo(() => {
+    return !datePresets.some(({ range }) => {
+      const { start, end } = range();
+      return start === dateStart && end === dateEnd;
+    });
+  }, [dateStart, dateEnd]);
+
+  const filtersDisabled = loading;
+
+  const presetButtons = datePresets.map(({ label, range }) => {
+    const { start, end } = range();
+    const active = start === dateStart && end === dateEnd;
+    return (
+      <button
+        key={label}
+        type="button"
+        disabled={filtersDisabled}
+        onClick={() => setDateRange(start, end)}
+        className={cn(
+          "rounded-xl px-3 py-1.5 text-sm transition",
+          "bg-[color:var(--surface-2)] text-[color:var(--muted)] hover:bg-[color:var(--primary-600)]/20",
+          active &&
+            "bg-[color:var(--primary)]/20 text-[color:var(--text)] ring-1 ring-[color:var(--primary)]/40",
+          filtersDisabled && "opacity-50"
+        )}
+        aria-pressed={active}
+      >
+        {label}
+      </button>
+    );
+  });
+
+  const customButton = (
+    <button
+      key="custom"
+      type="button"
+      disabled={filtersDisabled}
+      onClick={() => setIsCustomOpen(true)}
+      className={cn(
+        "rounded-xl px-3 py-1.5 text-sm transition",
+        "bg-[color:var(--surface-2)] text-[color:var(--muted)] hover:bg-[color:var(--primary-600)]/20",
+        isCustomRangeActive &&
+          "bg-[color:var(--primary)]/20 text-[color:var(--text)] ring-1 ring-[color:var(--primary)]/40",
+        filtersDisabled && "opacity-50"
+      )}
+      aria-pressed={isCustomRangeActive}
+    >
+      Custom
+    </button>
+  );
+
+  const datasetButtons = [
+    { key: "gdelt" as const, label: "GDELT" },
+    { key: "poly" as const, label: "Polymarket" },
+    ...(twitterDatasetEnabled ? ([{ key: "twitter" as const, label: "Twitter" }] as const) : []),
+  ].map(({ key, label }) => {
+    const active = datasets[key];
+    return (
+      <button
+        key={key}
+        type="button"
+        disabled={filtersDisabled || (key === "twitter" && !twitterDatasetEnabled)}
+        onClick={() => toggleDataset(key)}
+        className={cn(
+          "rounded-xl px-3 py-1.5 text-sm transition",
+          "bg-[color:var(--surface-2)] text-[color:var(--muted)] hover:bg-[color:var(--primary-600)]/20",
+          active &&
+            "bg-[color:var(--primary)]/20 text-[color:var(--text)] ring-1 ring-[color:var(--primary)]/40",
+          filtersDisabled && "opacity-50"
+        )}
+        aria-pressed={active}
+      >
+        {label}
+      </button>
+    );
+  });
+
+  return (
+    <div className="w-full max-w-[760px]">
+      {loading ? (
+        <div className="animate-pulse">
+          <div className="h-12 rounded-3xl bg-[color:var(--surface-2)]/80 lg:h-14" />
+        </div>
+      ) : (
+        <div
+          className={cn(
+            "flex items-center rounded-3xl px-5 shadow-[0_8px_30px_rgba(0,0,0,0.35)] transition",
+            "bg-[linear-gradient(180deg,rgba(255,255,255,0.02)_0%,rgba(0,0,0,0.15)_100%)]",
+            "border border-[color:var(--border)]/60",
+            "h-12 lg:h-14",
+            "hover:ring-1 hover:ring-[color:var(--primary)]/35",
+            "focus-within:ring-1 focus-within:ring-[color:var(--primary)]/35"
+          )}
+        >
+          <input
+            aria-label="Search events or markets"
+            placeholder="Search events or markets"
+            className="w-full bg-transparent text-[color:var(--text)] outline-none placeholder-[color:var(--muted)]"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            disabled={loading}
+          />
+          <button
+            type="button"
+            className="ml-2 hidden text-sm text-[color:var(--muted)] transition hover:text-[color:var(--text)] lg:inline"
+            onClick={() => setIsAdvancedOpen(true)}
+            disabled={loading}
+          >
+            Advanced
+          </button>
+        </div>
+      )}
+
+      {error ? (
+        <div className="mt-3 flex items-center justify-between rounded-2xl border border-red-500/40 bg-red-500/10 px-4 py-2 text-sm text-red-200">
+          <span>{error}</span>
+          <button
+            type="button"
+            className="rounded-lg border border-red-500/50 px-3 py-1 text-xs uppercase tracking-wide text-red-100 transition hover:bg-red-500/20"
+            onClick={onRetry}
+          >
+            Retry
+          </button>
+        </div>
+      ) : (
+        <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-[color:var(--muted)]">
+          <div className="flex flex-wrap items-center gap-2">
+            {presetButtons}
+            {customButton}
+          </div>
+          <span className="hidden h-5 w-px bg-[color:var(--border)]/60 sm:block" />
+          <div className="flex flex-wrap items-center gap-2">{datasetButtons}</div>
+          <button
+            type="button"
+            className={cn(
+              "ml-auto rounded-xl px-3 py-1.5 text-sm transition",
+              "bg-[color:var(--surface-2)] text-[color:var(--muted)] hover:bg-[color:var(--primary-600)]/20",
+              filtersDisabled && "opacity-50"
+            )}
+            onClick={() => setIsAdvancedOpen(true)}
+            disabled={filtersDisabled}
+          >
+            Advanced
+          </button>
+        </div>
+      )}
+
+      {isCustomOpen && (
+        <div className="mt-3 rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--surface)]/80 p-4 text-sm shadow-[0_18px_45px_rgba(0,0,0,0.45)]">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <label className="flex flex-1 flex-col gap-1 text-xs uppercase tracking-wide text-[color:var(--muted)]">
+              Start
+              <input
+                type="date"
+                value={formatDateForInput(customStart)}
+                onChange={(event) => {
+                  const value = parseDateFromInput(event.target.value);
+                  setCustomStart(value);
+                }}
+                className="rounded-xl border border-[color:var(--border)]/70 bg-[color:var(--surface-2)] px-3 py-2 text-[color:var(--text)]"
+              />
+            </label>
+            <label className="flex flex-1 flex-col gap-1 text-xs uppercase tracking-wide text-[color:var(--muted)]">
+              End
+              <input
+                type="date"
+                value={formatDateForInput(customEnd)}
+                onChange={(event) => {
+                  const value = parseDateFromInput(event.target.value);
+                  setCustomEnd(value);
+                }}
+                className="rounded-xl border border-[color:var(--border)]/70 bg-[color:var(--surface-2)] px-3 py-2 text-[color:var(--text)]"
+              />
+            </label>
+          </div>
+          <div className="mt-4 flex justify-end gap-2 text-xs uppercase tracking-wide">
+            <button
+              type="button"
+              className="rounded-xl border border-[color:var(--border)]/70 px-3 py-1.5 text-[color:var(--muted)] transition hover:bg-[color:var(--primary-600)]/10"
+              onClick={() => setIsCustomOpen(false)}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="rounded-xl bg-[color:var(--primary)]/80 px-3 py-1.5 text-[color:var(--text)] shadow-[0_6px_25px_rgba(224,36,36,0.35)] transition hover:bg-[color:var(--primary)]"
+              onClick={() => {
+                const startValue = customStart;
+                const endValue = customEnd;
+                if (!startValue || !endValue) {
+                  return;
+                }
+
+                const ordered = startValue <= endValue ? [startValue, endValue] : [endValue, startValue];
+                setDateRange(ordered[0], ordered[1]);
+                setIsCustomOpen(false);
+              }}
+            >
+              Apply
+            </button>
+          </div>
+        </div>
+      )}
+
+      {isAdvancedOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-5"
+          role="presentation"
+          onClick={() => setIsAdvancedOpen(false)}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="advanced-search-title"
+            className="w-full max-w-lg rounded-3xl border border-[color:var(--border)]/70 bg-[color:var(--surface)] p-6 shadow-[0_25px_70px_rgba(0,0,0,0.6)]"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-center justify-between">
+              <h2 id="advanced-search-title" className="text-lg font-semibold text-[color:var(--text)]">
+                Advanced search
+              </h2>
+              <button
+                type="button"
+                className="rounded-full border border-[color:var(--border)]/70 px-3 py-1 text-xs text-[color:var(--muted)] transition hover:bg-[color:var(--primary-600)]/20"
+                onClick={() => setIsAdvancedOpen(false)}
+              >
+                Close
+              </button>
+            </div>
+            <p className="mt-4 text-sm text-[color:var(--muted)]">
+              Configure advanced filters and saved searches. This is a placeholder for future enhancements.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,14 @@
+import SearchBar from "./SearchBar";
+
+export default function TopBar() {
+  return (
+    <div className="sticky top-[var(--header-h)] z-40 bg-[color:var(--surface)]/90 backdrop-blur-md border-b border-[color:var(--border)]/60">
+      <div className="mx-auto w-full max-w-[1440px] px-5">
+        <div className="flex flex-col items-center py-3 md:py-4">
+          <SearchBar />
+          <div className="pointer-events-none mt-1 h-[2px] w-full max-w-[760px] rounded-full bg-gradient-to-r from-[color:var(--primary)]/50 via-transparent to-[color:var(--primary)]/30" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/stores/useGlobalFilters.ts
+++ b/src/stores/useGlobalFilters.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { create } from "zustand";
+
+const MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000;
+
+function formatDate(date: Date) {
+  return date.toISOString().slice(0, 10).replaceAll("-", "");
+}
+
+const now = new Date();
+const defaultEnd = formatDate(now);
+const defaultStart = formatDate(new Date(now.getTime() - 6 * MILLISECONDS_IN_DAY));
+
+export const twitterDatasetEnabled = process.env.NEXT_PUBLIC_ENABLE_TWITTER === "1";
+
+type DatasetKey = "gdelt" | "poly" | "twitter";
+
+type GlobalFiltersState = {
+  keywords: string[];
+  dateStart: string;
+  dateEnd: string;
+  datasets: Record<DatasetKey, boolean>;
+  setKeywords: (keywords: string[]) => void;
+  setDateRange: (start: string, end: string) => void;
+  toggleDataset: (dataset: DatasetKey) => void;
+};
+
+export const useGlobalFilters = create<GlobalFiltersState>((set) => ({
+  keywords: [],
+  dateStart: defaultStart,
+  dateEnd: defaultEnd,
+  datasets: {
+    gdelt: true,
+    poly: true,
+    twitter: twitterDatasetEnabled,
+  },
+  setKeywords: (keywords) => set({ keywords }),
+  setDateRange: (start, end) => set({ dateStart: start, dateEnd: end }),
+  toggleDataset: (dataset) =>
+    set((state) => {
+      if (dataset === "twitter" && !twitterDatasetEnabled) {
+        return state;
+      }
+
+      return {
+        datasets: {
+          ...state.datasets,
+          [dataset]: !state.datasets[dataset],
+        },
+      };
+    }),
+}));


### PR DESCRIPTION
## Summary
- add global CSS custom properties for header height and top bar spacing
- introduce a sticky TopBar component that centers the SearchBar beneath the header
- implement a debounced SearchBar with presets, dataset toggles, and a Zustand-backed global filters store

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd846c4ebc8328a7e906df400e497c