### PR TITLE
Configure theme foundation and query provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "recharts": "^2.12.7",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
+        "zod": "^4.1.11",
         "zustand": "^4.5.5"
       },
       "devDependencies": {
@@ -6560,6 +6561,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
     "recharts": "^2.12.7",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
+    "zod": "^4.1.11",
     "zustand": "^4.5.5"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.1.0",
     "@types/node": "20.17.10",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
-    "@eslint/eslintrc": "^3.1.0",
     "autoprefixer": "10.4.20",
     "eslint": "8.57.1",
     "eslint-config-next": "14.2.15",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -38,14 +40,18 @@
   }
 
   body {
-    @apply min-h-screen bg-bg text-text antialiased;
-    font-family: "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont,
-      "Segoe UI", system-ui, sans-serif;
+    @apply min-h-screen bg-[var(--bg)] font-sans antialiased text-[var(--text)];
   }
-}
 
-@layer utilities {
+  .h1 {
+    @apply text-2xl font-semibold tracking-tight md:text-3xl;
+  }
+
   .card {
-    @apply rounded-2xl border border-border bg-surface shadow-soft;
+    @apply rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-[0_8px_30px_rgba(0,0,0,0.25)];
+  }
+
+  .surface-pill {
+    @apply bg-gradient-to-b from-[var(--surface-2)] to-[var(--surface)] shadow-md ring-1 ring-inset ring-white/5;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,15 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Poppins } from "next/font/google";
 
-import { cn } from "@/lib/utils";
 import "./globals.css";
 import TopBar from "@/components/TopBar";
+import { ReactQueryProvider } from "./react-query-provider";
 
-const inter = Inter({
+const poppins = Poppins({
   subsets: ["latin"],
+  weight: ["400", "600", "700"],
   display: "swap",
+  variable: "--font-poppins",
 });
 
 export const metadata: Metadata = {
@@ -24,36 +26,38 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="bg-bg">
-      <body className={cn("min-h-screen bg-bg text-text antialiased", inter.className)}>
-        <div className="flex min-h-screen flex-col">
-          <header className="sticky top-0 z-50 border-b border-border/70 bg-surface/80 backdrop-blur">
-            <div className="mx-auto flex h-[72px] w-full max-w-none items-center justify-between px-5">
-              <span className="text-lg font-semibold tracking-tight">Poly</span>
-              <nav className="flex items-center gap-6 text-sm text-muted">
-                <a className="transition hover:text-text" href="#">
-                  Overview
-                </a>
-                <a className="transition hover:text-text" href="#">
-                  Reports
-                </a>
-                <a className="transition hover:text-text" href="#">
-                  Settings
-                </a>
-              </nav>
+    <html lang="en" className={poppins.variable}>
+      <body className={poppins.className}>
+        <ReactQueryProvider>
+          <div className="flex min-h-screen flex-col">
+            <header className="sticky top-0 z-50 border-b border-border/70 bg-surface/80 backdrop-blur">
+              <div className="mx-auto flex h-[72px] w-full max-w-none items-center justify-between px-5">
+                <span className="text-lg font-semibold tracking-tight">Poly</span>
+                <nav className="flex items-center gap-6 text-sm text-muted">
+                  <a className="transition hover:text-text" href="#">
+                    Overview
+                  </a>
+                  <a className="transition hover:text-text" href="#">
+                    Reports
+                  </a>
+                  <a className="transition hover:text-text" href="#">
+                    Settings
+                  </a>
+                </nav>
+              </div>
+            </header>
+            <TopBar />
+            <div className="flex-1 pb-10 pt-[var(--topbar-gap)]">
+              <main className="max-w-[1440px] px-5 mx-auto">{children}</main>
             </div>
-          </header>
-          <TopBar />
-          <main className="mx-auto w-full max-w-[1440px] flex-1 px-5 pb-10 pt-[var(--topbar-gap)]">
-            {children}
-          </main>
-          <footer className="border-t border-border/70 bg-surface/60">
-            <div className="mx-auto flex h-16 w-full max-w-none items-center justify-between px-5 text-xs text-muted">
-              <span>&copy; {new Date().getFullYear()} Poly UI</span>
-              <span>Built with Next.js 14 · Tailwind CSS · shadcn/ui</span>
-            </div>
-          </footer>
-        </div>
+            <footer className="border-t border-border/70 bg-surface/60">
+              <div className="mx-auto flex h-16 w-full max-w-none items-center justify-between px-5 text-xs text-muted">
+                <span>&copy; {new Date().getFullYear()} Poly UI</span>
+                <span>Built with Next.js 14 · Tailwind CSS · shadcn/ui</span>
+              </div>
+            </footer>
+          </div>
+        </ReactQueryProvider>
       </body>
     </html>
   );

--- a/src/app/react-query-provider.tsx
+++ b/src/app/react-query-provider.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+
+export function ReactQueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,14 +14,19 @@ const config: Config = {
       colors: {
         bg: "var(--bg)",
         surface: "var(--surface)",
+        surface2: "var(--surface-2)",
         "surface-2": "var(--surface-2)",
         primary: "var(--primary)",
+        primary600: "var(--primary-600)",
         "primary-600": "var(--primary-600)",
         accent: "var(--accent)",
         success: "var(--success)",
         text: "var(--text)",
         muted: "var(--muted)",
         border: "var(--border)",
+      },
+      fontFamily: {
+        sans: ["Poppins", "sans-serif"],
       },
       boxShadow: {
         soft: "0 30px 60px -30px rgba(9, 11, 17, 0.55)",


### PR DESCRIPTION
## Summary
- align Tailwind theming with nero/rosso variables and Poppins typography, including base utility classes for cards, headings, and pills
- refresh global styles and root layout to apply the new font, dark styling, and QueryClient-powered provider wrapper
- add a reusable React Query provider helper and bring in zod to match the requested dependency set

## Testing
- npm run lint *(fails: SyntaxError thrown from lodash.merge in eslint's dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd901811408328857f86965bca3d51