### PR TITLE
style: refresh dark ui theming

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Poppins font configured via next/font/google in layout */
 :root {
   --bg: #0b0b0c;
   --surface: #16181c;
@@ -38,13 +39,7 @@
   }
 
   body {
-    @apply min-h-screen bg-bg font-sans text-text antialiased;
-  }
-}
-
-@layer utilities {
-  .card {
-    @apply rounded-2xl border border-border bg-surface shadow-soft;
+    @apply min-h-screen bg-[var(--bg)] font-[family-name(poppins)] text-[var(--text)] antialiased;
   }
 }
 
@@ -53,18 +48,17 @@
 }
 
 .surface-pill {
-  background: linear-gradient(
-    180deg,
-    rgba(255, 255, 255, 0.03) 0%,
-    rgba(0, 0, 0, 0.18) 100%
-  );
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.06),
-    0 12px 30px rgba(0, 0, 0, 0.35);
+  @apply bg-gradient-to-b from-[var(--surface-2)] to-[var(--surface)] ring-inset ring-1 ring-white/5 shadow-md;
 }
 
 @layer components {
   .h1 {
-    @apply text-2xl font-semibold tracking-tight md:text-3xl;
+    @apply text-2xl md:text-3xl font-semibold tracking-tight;
+  }
+}
+
+@layer utilities {
+  .card {
+    @apply rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-[0_8px_30px_rgba(0,0,0,0.25)];
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Poppins } from "next/font/google";
 import { cn } from "@/lib/utils";
 import "./globals.css";
 import TopBar from "@/components/TopBar";
+import { AppQueryProvider } from "./query-client-provider";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -26,35 +27,42 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="bg-bg">
-      <body className={cn("min-h-screen bg-bg text-text antialiased", poppins.className)}>
-        <div className="flex min-h-screen flex-col">
-          <header className="sticky top-0 z-50 border-b border-border/70 bg-surface/80 backdrop-blur">
-            <div className="mx-auto flex h-[72px] w-full max-w-none items-center justify-between px-5">
-              <span className="text-lg font-semibold tracking-tight">Poly</span>
-              <nav className="flex items-center gap-6 text-sm text-muted">
-                <a className="transition hover:text-text" href="#">
-                  Overview
-                </a>
-                <a className="transition hover:text-text" href="#">
-                  Reports
-                </a>
-                <a className="transition hover:text-text" href="#">
-                  Settings
-                </a>
-              </nav>
-            </div>
-          </header>
-          <TopBar />
-          <main className="main-wrap mx-auto w-full max-w-[1440px] flex-1 px-5 pb-10">
-            {children}
-          </main>
-          <footer className="border-t border-border/70 bg-surface/60">
-            <div className="mx-auto flex h-16 w-full max-w-none items-center justify-between px-5 text-xs text-muted">
-              <span>&copy; {new Date().getFullYear()} Poly UI</span>
-              <span>Built with Next.js 14 · Tailwind CSS · shadcn/ui</span>
-            </div>
-          </footer>
-        </div>
+      <body
+        className={cn(
+          "min-h-screen bg-[var(--bg)] text-[var(--text)] antialiased",
+          poppins.className,
+        )}
+      >
+        <AppQueryProvider>
+          <div className="flex min-h-screen flex-col">
+            <header className="sticky top-0 z-50 border-b border-border/70 bg-surface/80 backdrop-blur">
+              <div className="mx-auto flex h-[72px] w-full max-w-none items-center justify-between px-5">
+                <span className="text-lg font-semibold tracking-tight">Poly</span>
+                <nav className="flex items-center gap-6 text-sm text-muted">
+                  <a className="transition hover:text-text" href="#">
+                    Overview
+                  </a>
+                  <a className="transition hover:text-text" href="#">
+                    Reports
+                  </a>
+                  <a className="transition hover:text-text" href="#">
+                    Settings
+                  </a>
+                </nav>
+              </div>
+            </header>
+            <TopBar />
+            <main className="main-wrap mx-auto w-full max-w-[1440px] flex-1 px-5 pb-10">
+              {children}
+            </main>
+            <footer className="border-t border-border/70 bg-surface/60">
+              <div className="mx-auto flex h-16 w-full max-w-none items-center justify-between px-5 text-xs text-muted">
+                <span>&copy; {new Date().getFullYear()} Poly UI</span>
+                <span>Built with Next.js 14 · Tailwind CSS · shadcn/ui</span>
+              </div>
+            </footer>
+          </div>
+        </AppQueryProvider>
       </body>
     </html>
   );

--- a/src/app/query-client-provider.tsx
+++ b/src/app/query-client-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function AppQueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,6 @@
 import type { Config } from "tailwindcss";
-import defaultTheme from "tailwindcss/defaultTheme";
 import animate from "tailwindcss-animate";
+import plugin from "tailwindcss/plugin";
 
 const config: Config = {
   darkMode: ["class"],
@@ -15,9 +15,9 @@ const config: Config = {
       colors: {
         bg: "var(--bg)",
         surface: "var(--surface)",
-        "surface-2": "var(--surface-2)",
+        surface2: "var(--surface-2)",
         primary: "var(--primary)",
-        "primary-600": "var(--primary-600)",
+        primary600: "var(--primary-600)",
         accent: "var(--accent)",
         success: "var(--success)",
         text: "var(--text)",
@@ -25,12 +25,7 @@ const config: Config = {
         border: "var(--border)",
       },
       fontFamily: {
-        sans: [
-          "Poppins",
-          "ui-sans-serif",
-          "system-ui",
-          ...defaultTheme.fontFamily.sans,
-        ],
+        sans: ["Poppins", "sans-serif"],
       },
       boxShadow: {
         soft: "0 30px 60px -30px rgba(9, 11, 17, 0.55)",
@@ -41,7 +36,22 @@ const config: Config = {
       },
     },
   },
-  plugins: [animate],
+  plugins: [
+    animate,
+    plugin(({ addUtilities }) => {
+      addUtilities({
+        ".h1": {
+          "@apply text-2xl md:text-3xl font-semibold tracking-tight": {},
+        },
+        ".card": {
+          "@apply rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-[0_8px_30px_rgba(0,0,0,0.25)] p-4": {},
+        },
+        ".surface-pill": {
+          "@apply bg-gradient-to-b from-[var(--surface-2)] to-[var(--surface)] ring-inset ring-1 ring-white/5 shadow-md": {},
+        },
+      });
+    }),
+  ],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- align tailwind theme tokens with dark dashboard palette and register shared utility classes for headings, cards, and pills
- refine global styles to apply the new variable-driven background, gradient surfaces, and pill treatments while keeping responsive spacing helpers intact
- wrap the application shell with React Query provider and apply the refreshed font and color classes at the layout level for consistency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd938bd7a08328b4b8fb8eac5ea2a1