### PR TITLE
Implement glassy search bar filters with custom date picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,17 @@
       "name": "poly",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-toast": "^1.2.15",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.62.9",
         "clsx": "^2.1.1",
         "framer-motion": "^11.11.17",
         "lucide-react": "^0.474.0",
         "next": "14.2.15",
         "react": "18.2.0",
+        "react-day-picker": "^9.11.0",
         "react-dom": "18.2.0",
         "recharts": "^2.12.7",
         "tailwind-merge": "^3.3.1",
@@ -54,6 +59,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.5.0",
@@ -195,6 +206,44 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -541,6 +590,588 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -710,7 +1341,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
@@ -1358,6 +1989,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -2121,6 +2764,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2187,6 +2846,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -3233,6 +3898,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -4982,6 +5656,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-day-picker": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.11.0.tgz",
+      "integrity": "sha512-L4FYOaPrr3+AEROeP6IG2mCORZZfxJDkJI2df8mv1jyPrNYeccgmFPZDaHyAuPCBCddQFozkxbikj2NhMEYfDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "^4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -5001,6 +5696,53 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-smooth": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
@@ -5014,6 +5756,28 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-transition-group": {
@@ -6283,6 +7047,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,17 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-toast": "^1.2.15",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.62.9",
     "clsx": "^2.1.1",
     "framer-motion": "^11.11.17",
     "lucide-react": "^0.474.0",
     "next": "14.2.15",
     "react": "18.2.0",
+    "react-day-picker": "^9.11.0",
     "react-dom": "18.2.0",
     "recharts": "^2.12.7",
     "tailwind-merge": "^3.3.1",
@@ -22,10 +27,10 @@
     "zustand": "^4.5.5"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.1.0",
     "@types/node": "20.17.10",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
-    "@eslint/eslintrc": "^3.1.0",
     "autoprefixer": "10.4.20",
     "eslint": "8.57.1",
     "eslint-config-next": "14.2.15",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -53,7 +53,7 @@
 
 @layer components {
   .h1 {
-    @apply text-2xl md:text-3xl font-semibold tracking-tight;
+    @apply text-2xl md:text-3xl font-bold tracking-tight;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Poppins } from "next/font/google";
 
 import { cn } from "@/lib/utils";
+import { Toaster } from "@/components/ui/toaster";
 import "./globals.css";
 import TopBar from "@/components/TopBar";
 import { AppQueryProvider } from "./query-client-provider";
@@ -37,7 +38,7 @@ export default function RootLayout({
           <div className="flex min-h-screen flex-col">
             <header className="sticky top-0 z-50 border-b border-border/70 bg-surface/80 backdrop-blur">
               <div className="mx-auto flex h-[72px] w-full max-w-none items-center justify-between px-5">
-                <span className="text-lg font-semibold tracking-tight">Poly</span>
+                <span className="text-lg font-bold tracking-tight">Poly</span>
                 <nav className="flex items-center gap-6 text-sm text-muted">
                   <a className="transition hover:text-text" href="#">
                     Overview
@@ -62,6 +63,7 @@ export default function RootLayout({
               </div>
             </footer>
           </div>
+          <Toaster />
         </AppQueryProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,12 @@
 export default function HomePage() {
   return (
-    <section className="flex min-h-[360px] items-center justify-center rounded-3xl border border-dashed border-[color:var(--border)]/70 bg-[color:var(--surface-2)]/50 text-sm text-[color:var(--muted)]">
-      <span>Dashboard content coming soon.</span>
-    </section>
+    <div className="grid grid-cols-1 gap-5 md:grid-cols-12">
+      {/* Placeholder tiles for upcoming dashboard sections */}
+      <div className="card md:col-span-8">Block A1</div>
+      <div className="card md:col-span-4">Block A2</div>
+      <div className="card md:col-span-6">Block B1</div>
+      <div className="card md:col-span-6">Block B2</div>
+      <div className="card md:col-span-12">Block C</div>
+    </div>
   );
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,16 +1,31 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import DatePresets from "@/components/search/DatePresets";
 import DatasetToggles from "@/components/search/DatasetToggles";
 import { CUSTOM_PRESET_EVENT, SEARCH_SUBMIT_EVENT } from "@/components/search/events";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
   twitterDatasetEnabled,
   useGlobalFilters,
 } from "@/stores/useGlobalFilters";
 import { Search } from "lucide-react";
+
+type SearchBarProps = {
+  loading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+  onSearch?: (keywords: string[]) => void;
+};
 
 const DEBOUNCE_DELAY = 300;
 
@@ -25,13 +40,6 @@ function keywordsEqual(a: string[], b: string[]) {
   if (a.length !== b.length) return false;
   return a.every((value, index) => value === b[index]);
 }
-
-type SearchBarProps = {
-  loading?: boolean;
-  error?: string | null;
-  onRetry?: () => void;
-  onSearch?: (keywords: string[]) => void;
-};
 
 export default function SearchBar({
   loading = false,
@@ -64,11 +72,6 @@ export default function SearchBar({
     return () => window.clearTimeout(handle);
   }, [query, keywords, setKeywords]);
 
-  const clearSearch = () => {
-    setQuery("");
-    setKeywords([]);
-  };
-
   const dispatchSearchEvent = (parsed: string[]) => {
     if (typeof window !== "undefined") {
       window.dispatchEvent(
@@ -77,6 +80,12 @@ export default function SearchBar({
         })
       );
     }
+  };
+
+  const clearSearch = () => {
+    setQuery("");
+    setKeywords([]);
+    dispatchSearchEvent([]);
   };
 
   const handleSubmit = () => {
@@ -153,6 +162,20 @@ export default function SearchBar({
     "md:h-14"
   );
 
+  const dialogContent = useMemo(
+    () => (
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Advanced search</DialogTitle>
+        </DialogHeader>
+        <div className="rounded-3xl border border-dashed border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/70 p-6 text-sm text-[color:var(--muted)]">
+          Controls coming soon.
+        </div>
+      </DialogContent>
+    ),
+    []
+  );
+
   return (
     <div className="mx-auto w-full max-w-[760px]">
       {loading ? (
@@ -169,7 +192,7 @@ export default function SearchBar({
             "focus-within:ring-2 focus-within:ring-[color:var(--primary)]/45"
           )}
         >
-          <Search className="mr-3 h-4 w-4 opacity-70" strokeWidth={2} />
+          <Search className="mr-3 h-4 w-4 text-[color:var(--muted)]" strokeWidth={2} />
           <input
             type="text"
             placeholder="Search events or markets"
@@ -202,6 +225,20 @@ export default function SearchBar({
       <div className="mt-2 flex flex-wrap items-center gap-2">
         <DatePresets disabled={loading} />
         <DatasetToggles disabled={loading} />
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="rounded-2xl border border-transparent bg-[color:var(--surface-2)]/80 px-3 text-[13px] text-[color:var(--muted)] transition hover:border-[color:var(--primary)]/35 hover:bg-[color:var(--primary)]/12 hover:text-[color:var(--text)]"
+              disabled={loading}
+            >
+              Advanced
+            </Button>
+          </DialogTrigger>
+          {dialogContent}
+        </Dialog>
       </div>
 
       <div className="pointer-events-none mt-1 h-[2px] rounded-full bg-[radial-gradient(60%_80%_at_50%_50%,rgba(224,36,36,0.45),transparent)]" />

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,6 +1,15 @@
+"use client";
+
+import { useCallback } from "react";
+
 import SearchBar from "./SearchBar";
 
 export default function TopBar() {
+  const handleSearch = useCallback((keywords: string) => {
+    // TODO: hook into analytics pipeline
+    console.log("Search:", keywords);
+  }, []);
+
   return (
     <div className="sticky top-[var(--header-h)] z-40 border-b border-[color:var(--border)]/60 bg-[color:var(--surface)]/85 backdrop-blur-md shadow-[0_10px_30px_rgba(0,0,0,0.35)]">
       <div className="relative">
@@ -11,10 +20,7 @@ export default function TopBar() {
             loading={false}
             error={null}
             onRetry={() => {}}
-            onSearch={(keywords) => {
-              // TODO: hook into analytics pipeline
-              console.log("Search:", keywords);
-            }}
+            onSearch={handleSearch}
           />
         </div>
       </div>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -2,14 +2,20 @@ import SearchBar from "./SearchBar";
 
 export default function TopBar() {
   return (
-    <div
-      className="sticky top-[var(--header-h)] z-40 border-b border-[color:var(--border)]/60 bg-[color:var(--surface)]/85 backdrop-blur-md shadow-[0_10px_30px_rgba(0,0,0,0.35)]"
-    >
+    <div className="sticky top-[var(--header-h)] z-40 border-b border-[color:var(--border)]/60 bg-[color:var(--surface)]/85 backdrop-blur-md shadow-[0_10px_30px_rgba(0,0,0,0.35)]">
       <div className="relative">
         <div className="absolute inset-x-0 -bottom-px h-px bg-gradient-to-r from-[color:var(--primary)]/35 via-transparent to-[color:var(--primary)]/35" />
         <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(120%_60%_at_50%_-10%,rgba(224,36,36,0.15),transparent_60%)]" />
         <div className="relative mx-auto max-w-[1440px] px-5 py-4">
-          <SearchBar />
+          <SearchBar
+            loading={false}
+            error={null}
+            onRetry={() => {}}
+            onSearch={(keywords) => {
+              // TODO: hook into analytics pipeline
+              console.log("Search:", keywords);
+            }}
+          />
         </div>
       </div>
     </div>

--- a/src/components/search/DatasetToggles.tsx
+++ b/src/components/search/DatasetToggles.tsx
@@ -8,7 +8,7 @@ import {
   twitterDatasetEnabled,
   useGlobalFilters,
 } from "@/stores/useGlobalFilters";
-import { BarChart3, Globe2, Twitter } from "lucide-react";
+import { BarChart, Search, Twitter } from "lucide-react";
 
 const chipClass = cn(
   "inline-flex items-center gap-1.5 rounded-2xl px-3 py-1.5 text-[13px] transition-all",
@@ -32,8 +32,8 @@ type DatasetOption = {
 };
 
 const datasetOptions: DatasetOption[] = [
-  { key: "gdelt", label: "GDELT", icon: Globe2 },
-  { key: "poly", label: "Polymarket", icon: BarChart3 },
+  { key: "gdelt", label: "GDELT", icon: Search },
+  { key: "poly", label: "Polymarket", icon: BarChart },
   { key: "twitter", label: "Twitter", icon: Twitter },
 ];
 
@@ -62,8 +62,8 @@ export default function DatasetToggles({ disabled = false }: DatasetTogglesProps
               toggleDataset(key);
             }}
           >
-            <Icon className="h-3.5 w-3.5 opacity-70" strokeWidth={2} />
-            <span>{label}</span>
+            <Icon className="h-3.5 w-3.5 opacity-75" strokeWidth={2} />
+            <span className="font-semibold tracking-tight">{label}</span>
           </button>
         );
       })}

--- a/src/components/search/DatePresets.tsx
+++ b/src/components/search/DatePresets.tsx
@@ -1,8 +1,17 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { CUSTOM_PRESET_EVENT } from "@/components/search/events";
+import { DateRangePicker, DateRange } from "@/components/ui/date-range-picker";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useToast } from "@/components/ui/use-toast";
 import { cn } from "@/lib/utils";
 import {
   Preset,
@@ -10,6 +19,8 @@ import {
   useGlobalFilters,
   utcYYYYMMDD,
 } from "@/stores/useGlobalFilters";
+
+const MAX_RANGE_DAYS = 365;
 
 const chipClass = cn(
   "rounded-2xl px-3 py-1.5 text-[13px] transition-all",
@@ -21,8 +32,6 @@ const chipClass = cn(
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--primary)]/45",
   "disabled:cursor-not-allowed disabled:opacity-50"
 );
-
-const MAX_RANGE_DAYS = 365;
 
 const presetOptions: Array<{ label: Exclude<Preset, "CUSTOM">; days: number }> = [
   { label: "7D", days: 7 },
@@ -37,27 +46,14 @@ function formatTooltip(start: string, end: string) {
   return `${toDisplay(start)} → ${toDisplay(end)}`;
 }
 
-function toDateInputValue(value: string) {
-  if (value.length !== 8) return "";
-  return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
-}
-
-function fromDateInputValue(value: string) {
-  if (!value) return "";
-  const [year, month, day] = value.split("-");
-  if (!year || !month || !day) return "";
-  return `${year}${month}${day}`;
-}
-
-function parseUTCDate(value: string) {
-  if (value.length !== 8) return null;
+function parseUTCDate(value: string): Date {
   const year = Number(value.slice(0, 4));
   const month = Number(value.slice(4, 6));
   const day = Number(value.slice(6, 8));
   return new Date(Date.UTC(year, month - 1, day));
 }
 
-function diffInDays(start: Date, end: Date) {
+function differenceInDays(start: Date, end: Date) {
   const diff = end.getTime() - start.getTime();
   return Math.floor(diff / (24 * 60 * 60 * 1000)) + 1;
 }
@@ -73,193 +69,114 @@ export default function DatePresets({ disabled = false }: DatePresetsProps) {
   const setPreset = useGlobalFilters((state) => state.setPreset);
   const setDateRange = useGlobalFilters((state) => state.setDateRange);
 
-  const [isCustomOpen, setIsCustomOpen] = useState(false);
-  const [customStart, setCustomStart] = useState(dateStart);
-  const [customEnd, setCustomEnd] = useState(dateEnd);
-  const [customError, setCustomError] = useState<string | null>(null);
+  const { toast } = useToast();
 
-  const popoverRef = useRef<HTMLDivElement | null>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
-
-  useEffect(() => {
-    if (!isCustomOpen) {
-      setCustomStart(dateStart);
-      setCustomEnd(dateEnd);
-      setCustomError(null);
-    }
-  }, [dateStart, dateEnd, isCustomOpen]);
+  const [customOpen, setCustomOpen] = useState(false);
+  const parsedRange = useMemo<DateRange>(
+    () => ({ from: parseUTCDate(dateStart), to: parseUTCDate(dateEnd) }),
+    [dateStart, dateEnd]
+  );
+  const [pendingRange, setPendingRange] = useState<DateRange>(() => parsedRange);
 
   useEffect(() => {
-    if (activePreset !== "CUSTOM" && isCustomOpen) {
-      setIsCustomOpen(false);
+    if (!customOpen) {
+      setPendingRange(parsedRange);
     }
-  }, [activePreset, isCustomOpen]);
+  }, [customOpen, parsedRange]);
 
   useEffect(() => {
     const handleOpen = () => {
       if (!disabled) {
-        setIsCustomOpen(true);
-        setCustomError(null);
+        setPreset("CUSTOM");
+        setCustomOpen(true);
       }
     };
 
     document.addEventListener(CUSTOM_PRESET_EVENT, handleOpen);
     return () => document.removeEventListener(CUSTOM_PRESET_EVENT, handleOpen);
-  }, [disabled]);
+  }, [disabled, setPreset]);
 
-  useEffect(() => {
-    if (!isCustomOpen) return;
+  const handleApply = (range: Required<DateRange>) => {
+    const from = range.from <= range.to ? range.from : range.to;
+    const to = range.to >= range.from ? range.to : range.from;
+    const days = differenceInDays(from, to);
 
-    const handleClick = (event: MouseEvent) => {
-      const target = event.target as Node | null;
-      if (
-        target &&
-        popoverRef.current &&
-        !popoverRef.current.contains(target) &&
-        triggerRef.current &&
-        !triggerRef.current.contains(target)
-      ) {
-        setIsCustomOpen(false);
-      }
-    };
+    if (days > MAX_RANGE_DAYS) {
+      toast({
+        title: "Range too large",
+        description: "Custom ranges are limited to 365 days.",
+      });
+      return;
+    }
 
-    const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setIsCustomOpen(false);
-      }
-    };
+    setDateRange(utcYYYYMMDD(from), utcYYYYMMDD(to), "CUSTOM");
+    setCustomOpen(false);
+  };
 
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleKey);
-
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleKey);
-    };
-  }, [isCustomOpen]);
-
-  const customTooltip = useMemo(
-    () => formatTooltip(dateStart, dateEnd),
-    [dateStart, dateEnd]
-  );
+  const customTooltip = formatTooltip(dateStart, dateEnd);
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      {presetOptions.map((preset) => {
-        const { start, end } = presetRange(preset.days);
-        const isActive = activePreset === preset.label;
-        return (
-          <button
-            key={preset.label}
-            type="button"
-            title={formatTooltip(start, end)}
-            data-active={isActive ? "true" : undefined}
-            className={chipClass}
-            disabled={disabled}
-            onClick={() => setPreset(preset.label)}
-          >
-            {preset.label}
-          </button>
-        );
-      })}
+    <TooltipProvider>
+      <div className="flex flex-wrap items-center gap-2">
+        {presetOptions.map((preset) => {
+          const { start, end } = presetRange(preset.days);
+          const isActive = activePreset === preset.label;
+          const tooltip = formatTooltip(start, end);
 
-      <div className="relative">
-        <button
-          ref={triggerRef}
-          type="button"
-          title={customTooltip}
-          data-active={activePreset === "CUSTOM" ? "true" : undefined}
-          className={chipClass}
-          disabled={disabled}
-          onClick={() => setIsCustomOpen((open) => !open)}
+          return (
+            <Tooltip key={preset.label}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  title={tooltip}
+                  data-active={isActive ? "true" : undefined}
+                  className={chipClass}
+                  disabled={disabled}
+                  onClick={() => setPreset(preset.label)}
+                >
+                  {preset.label}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{tooltip}</TooltipContent>
+            </Tooltip>
+          );
+        })}
+
+        <Popover
+          open={customOpen}
+          onOpenChange={(open) => {
+            if (disabled) return;
+            setCustomOpen(open);
+            if (open) {
+              setPreset("CUSTOM");
+            }
+          }}
         >
-          Custom
-        </button>
-
-        {isCustomOpen && (
-          <div
-            ref={popoverRef}
-            className="surface-pill absolute right-0 z-50 mt-2 w-72 rounded-3xl border border-[color:var(--border)]/70 bg-[color:var(--surface)]/95 p-4 text-sm shadow-[0_18px_45px_rgba(0,0,0,0.45)]"
-          >
-            <div className="flex flex-col gap-3">
-              <label className="flex flex-col gap-1 text-[11px] uppercase tracking-wide text-[color:var(--muted)]">
-                Start date
-                <input
-                  type="date"
-                  value={toDateInputValue(customStart)}
-                  onChange={(event) => {
-                    setCustomStart(fromDateInputValue(event.target.value));
-                    setCustomError(null);
-                  }}
-                  className="rounded-2xl border border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/80 px-3 py-2 text-[color:var(--text)] focus:outline-none focus:ring-2 focus:ring-[color:var(--primary)]/35"
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-[11px] uppercase tracking-wide text-[color:var(--muted)]">
-                End date
-                <input
-                  type="date"
-                  value={toDateInputValue(customEnd)}
-                  onChange={(event) => {
-                    setCustomEnd(fromDateInputValue(event.target.value));
-                    setCustomError(null);
-                  }}
-                  className="rounded-2xl border border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/80 px-3 py-2 text-[color:var(--text)] focus:outline-none focus:ring-2 focus:ring-[color:var(--primary)]/35"
-                />
-              </label>
-            </div>
-
-            {customError && (
-              <p className="mt-3 rounded-2xl border border-red-500/30 bg-red-500/10 px-3 py-2 text-[12px] text-red-100">
-                {customError}
-              </p>
-            )}
-
-            <div className="mt-4 flex justify-end gap-2 text-[12px] font-medium uppercase tracking-wide">
-              <button
-                type="button"
-                className="rounded-2xl border border-[color:var(--border)]/60 px-3 py-1.5 text-[color:var(--muted)] transition hover:bg-[color:var(--primary-600)]/15 hover:text-[color:var(--text)]"
-                onClick={() => setIsCustomOpen(false)}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="rounded-2xl bg-[color:var(--primary)]/85 px-3 py-1.5 text-[color:var(--text)] shadow-[0_10px_30px_rgba(224,36,36,0.35)] transition hover:bg-[color:var(--primary)]"
-                onClick={() => {
-                  if (!customStart || !customEnd) {
-                    setCustomError("Select a valid start and end date.");
-                    return;
-                  }
-
-                  const startDate = parseUTCDate(customStart);
-                  const endDate = parseUTCDate(customEnd);
-
-                  if (!startDate || !endDate) {
-                    setCustomError("Invalid date range.");
-                    return;
-                  }
-
-                  const ordered = startDate <= endDate ? [startDate, endDate] : [endDate, startDate];
-                  const days = diffInDays(ordered[0], ordered[1]);
-
-                  if (days > MAX_RANGE_DAYS) {
-                    setCustomError("Ranges are limited to 365 days.");
-                    return;
-                  }
-
-                  const startValue = utcYYYYMMDD(ordered[0]);
-                  const endValue = utcYYYYMMDD(ordered[1]);
-
-                  setDateRange(startValue, endValue, "CUSTOM");
-                  setIsCustomOpen(false);
-                }}
-              >
-                Apply
-              </button>
-            </div>
-          </div>
-        )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  className={chipClass}
+                  data-active={activePreset === "CUSTOM" ? "true" : undefined}
+                  disabled={disabled}
+                >
+                  Custom
+                </button>
+              </PopoverTrigger>
+            </TooltipTrigger>
+            <TooltipContent>{customTooltip}</TooltipContent>
+          </Tooltip>
+          <PopoverContent className="w-[320px] md:w-[540px]">
+            <DateRangePicker
+              value={pendingRange}
+              onChange={(range) => setPendingRange(range ?? {})}
+              onCancel={() => setCustomOpen(false)}
+              onApply={handleApply}
+            />
+          </PopoverContent>
+        </Popover>
       </div>
-    </div>
+    </TooltipProvider>
   );
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type ButtonVariant = "default" | "outline" | "ghost" | "secondary";
+type ButtonSize = "default" | "sm" | "lg" | "icon";
+
+const variantClasses: Record<ButtonVariant, string> = {
+  default:
+    "bg-[color:var(--primary)] text-[color:var(--text)] shadow-[0_12px_35px_rgba(224,36,36,0.35)] hover:bg-[color:var(--primary-600)]",
+  outline:
+    "border border-[color:var(--border)]/70 bg-transparent text-[color:var(--text)] hover:border-[color:var(--primary)]/45 hover:bg-[color:var(--primary)]/10",
+  ghost:
+    "text-[color:var(--muted)] hover:text-[color:var(--text)] hover:bg-[color:var(--primary)]/10",
+  secondary:
+    "bg-[color:var(--surface-2)] text-[color:var(--text)] hover:bg-[color:var(--surface)]",
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  default: "h-10 px-4 py-2 text-sm font-semibold",
+  sm: "h-8 px-3 text-xs font-semibold",
+  lg: "h-12 px-6 text-sm font-semibold",
+  icon: "h-10 w-10",
+};
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "default", size = "default", ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          "inline-flex items-center justify-center gap-2 rounded-2xl transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--primary)]/45 disabled:pointer-events-none disabled:opacity-50",
+          variantClasses[variant],
+          sizeClasses[size],
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Button.displayName = "Button";
+
+export { Button };

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import * as React from "react";
+import { DayPicker } from "react-day-picker";
+
+import { cn } from "@/lib/utils";
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: CalendarProps) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn("space-y-4", className)}
+      classNames={{
+        months: "grid grid-cols-1 md:grid-cols-2 gap-4",
+        month: "space-y-4",
+        month_caption: "flex items-center justify-between px-4",
+        caption_label: "text-sm font-semibold text-[color:var(--text)]",
+        nav: "flex items-center gap-1",
+        button_previous:
+          "inline-flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--surface-2)]/70 text-[color:var(--muted)] transition hover:text-[color:var(--text)]",
+        button_next:
+          "inline-flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--surface-2)]/70 text-[color:var(--muted)] transition hover:text-[color:var(--text)]",
+        table: "w-full border-collapse space-y-1",
+        head_row: "grid grid-cols-7 text-xs uppercase tracking-wide text-[color:var(--muted)]",
+        head_cell: "flex h-8 items-center justify-center font-semibold",
+        row: "grid grid-cols-7 text-sm",
+        cell: cn(
+          "relative flex h-9 w-9 items-center justify-center text-sm transition",
+          "focus-within:relative focus-within:z-20"
+        ),
+        day: cn(
+          "inline-flex h-8 w-8 items-center justify-center rounded-full text-[color:var(--muted)] transition",
+          "hover:bg-[color:var(--primary)]/20 hover:text-[color:var(--text)]"
+        ),
+        day_range_start:
+          "bg-[color:var(--primary)]/80 text-[color:var(--text)] hover:bg-[color:var(--primary)]/80",
+        day_range_end:
+          "bg-[color:var(--primary)]/80 text-[color:var(--text)] hover:bg-[color:var(--primary)]/80",
+        day_range_middle:
+          "rounded-none bg-[color:var(--primary)]/30 text-[color:var(--text)]",
+        day_selected:
+          "bg-[color:var(--primary)]/80 text-[color:var(--text)] hover:bg-[color:var(--primary)]/80",
+        day_today: "border border-[color:var(--primary)]/40",
+        ...classNames,
+      }}
+      {...props}
+    />
+  );
+}
+
+Calendar.displayName = "Calendar";
+
+export { Calendar };

--- a/src/components/ui/date-range-picker.tsx
+++ b/src/components/ui/date-range-picker.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Calendar as CalendarIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import { Button } from "./button";
+import { Calendar } from "./calendar";
+
+export type DateRange = {
+  from?: Date;
+  to?: Date;
+};
+
+export interface DateRangePickerProps {
+  value: DateRange;
+  onChange: (range: DateRange | undefined) => void;
+  onApply: (range: Required<DateRange>) => void;
+  onCancel?: () => void;
+}
+
+function formatDate(date?: Date) {
+  if (!date) return "--";
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+  }).format(date);
+}
+
+export function DateRangePicker({
+  value,
+  onChange,
+  onApply,
+  onCancel,
+}: DateRangePickerProps) {
+  const handleApply = () => {
+    if (!value.from || !value.to) return;
+    onApply({ from: value.from, to: value.to });
+  };
+
+  return (
+    <div className="space-y-4">
+      <Calendar
+        mode="range"
+        numberOfMonths={2}
+        selected={value}
+        onSelect={onChange}
+        defaultMonth={value.from ?? new Date()}
+      />
+
+      <div className="flex items-center justify-between rounded-2xl bg-[color:var(--surface-2)]/60 px-4 py-3 text-xs uppercase tracking-wide text-[color:var(--muted)]">
+        <div className="flex items-center gap-2">
+          <CalendarIcon className="h-4 w-4 opacity-70" />
+          <div className="flex flex-col text-[color:var(--text)] normal-case">
+            <span className="text-[11px] uppercase tracking-wider text-[color:var(--muted)]">From</span>
+            <span className="text-sm font-semibold text-[color:var(--text)]">{formatDate(value.from)}</span>
+          </div>
+        </div>
+        <span className="px-2 text-[color:var(--muted)]">→</span>
+        <div className="flex flex-col text-[color:var(--text)] normal-case">
+          <span className="text-[11px] uppercase tracking-wider text-[color:var(--muted)]">To</span>
+          <span className="text-sm font-semibold text-[color:var(--text)]">{formatDate(value.to)}</span>
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2">
+        {onCancel ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="rounded-2xl"
+            onClick={onCancel}
+          >
+            Cancel
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          size="sm"
+          className={cn(
+            "rounded-2xl px-4",
+            (!value.from || !value.to) && "pointer-events-none opacity-40"
+          )}
+          onClick={handleApply}
+          disabled={!value.from || !value.to}
+        >
+          Apply
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in",
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-xl translate-x-[-50%] translate-y-[-50%] gap-6 rounded-[28px] border border-[color:var(--border)]/70 bg-[color:var(--surface)]/95 p-8 shadow-[0_25px_70px_rgba(0,0,0,0.55)]",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+      className
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-bold tracking-tight text-[color:var(--text)]",
+      className
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn(
+      "text-sm text-[color:var(--muted)]",
+      className
+    )}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+};

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+
+import { cn } from "@/lib/utils";
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "end", sideOffset = 8, ...props }, ref) => (
+  <PopoverPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 w-80 rounded-[24px] border border-[color:var(--border)]/70 bg-[color:var(--surface)]/95 p-4 shadow-[0_22px_60px_rgba(0,0,0,0.5)] outline-none",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in",
+      className
+    )}
+    {...props}
+  />
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverContent };

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import * as React from "react";
+import * as ToastPrimitives from "@radix-ui/react-toast";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const ToastProvider = ToastPrimitives.Provider;
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed bottom-6 right-6 z-[100] flex max-h-screen w-full max-w-sm flex-col gap-3",
+      className
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root>;
+
+type ToastActionElement = React.ReactElement;
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  ToastProps
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Root
+    ref={ref}
+    className={cn(
+      "relative rounded-3xl border border-[color:var(--border)]/70 bg-[color:var(--surface)]/95 p-4 pr-10 text-sm shadow-[0_18px_45px_rgba(0,0,0,0.45)]",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+      className
+    )}
+    {...props}
+  />
+));
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 items-center rounded-2xl border border-[color:var(--border)]/70 px-3 text-xs font-semibold uppercase tracking-wide text-[color:var(--text)] transition hover:bg-[color:var(--primary)]/20",
+      className
+    )}
+    {...props}
+  />
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-3 top-3 rounded-full p-1 text-[color:var(--muted)] transition hover:text-[color:var(--text)]",
+      className
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold text-[color:var(--text)]", className)}
+    {...props}
+  />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("mt-1 text-xs text-[color:var(--muted)]", className)}
+    {...props}
+  />
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+export type { ToastProps, ToastActionElement };
+
+export {
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastAction,
+  ToastClose,
+};

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useToast } from "./use-toast";
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "./toast";
+
+export function Toaster() {
+  const { toasts } = useToast();
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({ id, title, description, action, ...props }) {
+        return (
+          <Toast key={id} {...props}>
+            {title ? <ToastTitle>{title}</ToastTitle> : null}
+            {description ? <ToastDescription>{description}</ToastDescription> : null}
+            {action}
+            <ToastClose />
+          </Toast>
+        );
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@/lib/utils";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 max-w-xs rounded-2xl border border-white/10 bg-black/75 px-3 py-1.5 text-xs text-white shadow-lg backdrop-blur",
+      className
+    )}
+    {...props}
+  />
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent };

--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -1,0 +1,144 @@
+"use client";
+
+import * as React from "react";
+
+import type { ToastActionElement, ToastProps } from "./toast";
+
+const TOAST_LIMIT = 1;
+const TOAST_REMOVE_DELAY = 1000000;
+
+type ToasterToast = ToastProps & {
+  id: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  action?: ToastActionElement;
+};
+
+type Toast = Omit<ToasterToast, "id">;
+
+type State = {
+  toasts: ToasterToast[];
+};
+
+type Action =
+  | { type: "ADD_TOAST"; toast: ToasterToast }
+  | { type: "UPDATE_TOAST"; toast: Partial<ToasterToast> & { id: string } }
+  | { type: "DISMISS_TOAST"; toastId?: string }
+  | { type: "REMOVE_TOAST"; toastId?: string };
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+const listeners: Array<(state: State) => void> = [];
+let memoryState: State = { toasts: [] };
+
+function addToRemoveQueue(toastId: string) {
+  if (toastTimeouts.has(toastId)) {
+    return;
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId);
+    dispatch({ type: "REMOVE_TOAST", toastId });
+  }, TOAST_REMOVE_DELAY);
+
+  toastTimeouts.set(toastId, timeout);
+}
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      };
+    case "UPDATE_TOAST":
+      return {
+        ...state,
+        toasts: state.toasts.map((toast) =>
+          toast.id === action.toast.id ? { ...toast, ...action.toast } : toast
+        ),
+      };
+    case "DISMISS_TOAST": {
+      const { toastId } = action;
+
+      if (toastId) {
+        addToRemoveQueue(toastId);
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id);
+        });
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((toast) =>
+          toast.id === toastId || toastId === undefined
+            ? { ...toast, open: false }
+            : toast
+        ),
+      };
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === undefined) {
+        return { ...state, toasts: [] };
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((toast) => toast.id !== action.toastId),
+      };
+    default:
+      return state;
+  }
+}
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action);
+  listeners.forEach((listener) => {
+    listener(memoryState);
+  });
+}
+
+function toast({ ...props }: Toast) {
+  const id = Math.random().toString(36).slice(2, 9);
+
+  const update = (props: ToastProps) =>
+    dispatch({ type: "UPDATE_TOAST", toast: { ...props, id } });
+  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id });
+
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+    },
+  });
+
+  return {
+    id,
+    dismiss,
+    update,
+  };
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState);
+
+  React.useEffect(() => {
+    listeners.push(setState);
+    return () => {
+      const index = listeners.indexOf(setState);
+      if (index > -1) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, []);
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+  };
+}
+
+export { useToast, toast };


### PR DESCRIPTION
## Summary
- add shadcn-inspired UI primitives (buttons, dialog, popover, tooltip, toast, calendar) to support new search controls
- overhaul the search bar to use Zustand-backed date presets, dataset toggles, and an advanced dialog while wiring the top bar and layout
- refresh dashboard scaffolding and typography to emphasize Poppins styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd96167ec483289318b8b3caf2bfe3