### PR TITLE
Add GDELT and Polymarket proxy API routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "recharts": "^2.12.7",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
+        "zod": "^4.1.11",
         "zustand": "^4.5.5"
       },
       "devDependencies": {
@@ -7367,6 +7368,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "recharts": "^2.12.7",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
+    "zod": "^4.1.11",
     "zustand": "^4.5.5"
   },
   "devDependencies": {

--- a/src/app/api/gdelt/route.ts
+++ b/src/app/api/gdelt/route.ts
@@ -1,0 +1,123 @@
+import { NextResponse } from 'next/server';
+
+import { fetchWithTimeout } from '@/lib/api';
+import { gdeltQuerySchema } from '@/lib/validation';
+
+const ACTIONS_REQUIRING_DATES = new Set([
+  'context',
+  'country',
+  'bilateral',
+  'bilateral_conflict_coverage',
+]);
+
+const MAX_DAILY_RANGE_DAYS = 365;
+
+const parseDate = (value: string) =>
+  new Date(
+    Date.UTC(
+      Number(value.slice(0, 4)),
+      Number(value.slice(4, 6)) - 1,
+      Number(value.slice(6, 8)),
+    ),
+  );
+
+export async function GET(req: Request) {
+  const baseUrl = process.env.GDELT_BASE_URL;
+  if (!baseUrl) {
+    return NextResponse.json(
+      { status: 'error', message: 'GDELT_BASE_URL is not configured' },
+      { status: 500 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const rawParams = Object.fromEntries(url.searchParams.entries());
+  const validation = gdeltQuerySchema.safeParse(rawParams);
+
+  if (!validation.success) {
+    return NextResponse.json(
+      {
+        status: 'error',
+        message: 'Invalid query parameters',
+        issues: validation.error.flatten(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const params = validation.data;
+  const action = params.action ?? '';
+  const requiresDates = ACTIONS_REQUIRING_DATES.has(action);
+
+  const dateStart = params.date_start;
+  const dateEnd = params.date_end;
+
+  if (requiresDates && (!dateStart || !dateEnd)) {
+    return NextResponse.json(
+      {
+        status: 'error',
+        message: 'date_start and date_end are required for the selected action',
+      },
+      { status: 400 },
+    );
+  }
+
+  if (dateStart && dateEnd) {
+    const startDate = parseDate(dateStart);
+    const endDate = parseDate(dateEnd);
+
+    if (startDate > endDate) {
+      return NextResponse.json(
+        {
+          status: 'error',
+          message: 'date_start must be before date_end',
+        },
+        { status: 400 },
+      );
+    }
+
+    const diffDays = Math.abs((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
+    if (diffDays > MAX_DAILY_RANGE_DAYS) {
+      return NextResponse.json(
+        {
+          status: 'error',
+          message: 'Daily queries limited to 365 days maximum. Use monthly fallback',
+        },
+        { status: 400 },
+      );
+    }
+  }
+
+  const targetUrl = `${baseUrl}?${url.searchParams.toString()}`;
+  const response = await fetchWithTimeout(targetUrl);
+
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch (error) {
+    const message =
+      error instanceof Error && error.name === 'SyntaxError'
+        ? 'Invalid JSON response from GDELT'
+        : (error as Error)?.message ?? 'Unable to parse response';
+
+    return NextResponse.json(
+      { status: 'error', message },
+      { status: 502 },
+    );
+  }
+
+  if (!response.ok) {
+    const status = response.status || 502;
+    const message =
+      data && typeof data === 'object' && 'message' in (data as Record<string, unknown>)
+        ? String((data as { message?: unknown }).message)
+        : 'Upstream request failed';
+
+    return NextResponse.json(
+      { status: 'error', message },
+      { status },
+    );
+  }
+
+  return NextResponse.json(data, { status: response.status });
+}

--- a/src/app/api/poly/helpers.ts
+++ b/src/app/api/poly/helpers.ts
@@ -1,0 +1,224 @@
+export type GammaMarket = Record<string, unknown>;
+
+export type NormalizedToken = {
+  id: string;
+  outcome: 'YES' | 'NO';
+  price?: number;
+};
+
+export type NormalizedMarket = {
+  id: string;
+  title: string;
+  endDate: string | null;
+  volume24h: number;
+  liquidity: number;
+  status: string;
+  category?: string;
+  tokens: NormalizedToken[];
+  priceYes?: number;
+  priceNo?: number;
+};
+
+export const toNumber = (value: unknown): number => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+};
+
+const normalizeOutcomeName = (value: unknown): 'YES' | 'NO' => {
+  if (typeof value === 'string') {
+    const upper = value.toUpperCase();
+    if (upper.includes('NO')) {
+      return 'NO';
+    }
+  }
+
+  return 'YES';
+};
+
+export const normalizeTokens = (market: GammaMarket): NormalizedToken[] => {
+  const candidateCollections = [
+    market.outcomes,
+    market.tokens,
+    market.outcomeTokens,
+  ];
+
+  for (const collection of candidateCollections) {
+    if (Array.isArray(collection) && collection.length > 0) {
+      return collection
+        .map((token) => {
+          if (!token || typeof token !== 'object') {
+            return undefined;
+          }
+
+          if (!('id' in token)) {
+            return undefined;
+          }
+
+          const rawTokenId = (token as { id: unknown }).id;
+          if (rawTokenId === undefined || rawTokenId === null) {
+            return undefined;
+          }
+
+          const tokenId = String(rawTokenId);
+          if (!tokenId) {
+            return undefined;
+          }
+
+          const outcomeName =
+            ('outcome' in token && typeof token.outcome === 'string')
+              ? token.outcome
+              : ('name' in token && typeof token.name === 'string')
+                ? token.name
+                : ('title' in token && typeof token.title === 'string')
+                  ? token.title
+                  : 'YES';
+
+          const priceValue =
+            'price' in token
+              ? (token.price as unknown)
+              : 'lastPrice' in token
+                ? (token.lastPrice as unknown)
+                : 'mid' in token
+                  ? (token.mid as unknown)
+                  : undefined;
+
+          const price = priceValue === undefined ? undefined : toNumber(priceValue);
+
+          return {
+            id: tokenId,
+            outcome: normalizeOutcomeName(outcomeName),
+            price: price === 0 && priceValue === undefined ? undefined : price,
+          } satisfies NormalizedToken;
+        })
+        .filter((token): token is NormalizedToken => Boolean(token));
+    }
+  }
+
+  return [];
+};
+
+const pickString = (market: GammaMarket, keys: string[]): string | undefined => {
+  for (const key of keys) {
+    const value = market[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+
+  return undefined;
+};
+
+const pickNumber = (market: GammaMarket, keys: string[]): number => {
+  for (const key of keys) {
+    if (key in market) {
+      const value = market[key];
+      const parsed = toNumber(value);
+      if (parsed !== 0 || value === 0 || value === '0') {
+        return parsed;
+      }
+    }
+  }
+
+  return 0;
+};
+
+export const normalizeMarket = (market: GammaMarket): NormalizedMarket | null => {
+  const idValue = market.id ?? market.marketId ?? market.slug;
+  if (typeof idValue !== 'string' || !idValue) {
+    return null;
+  }
+
+  const title =
+    pickString(market, ['question', 'title', 'name', 'slug']) ??
+    `Market ${idValue}`;
+
+  const endDate = pickString(market, ['endDate', 'endTime', 'end_time', 'closeTime']) ?? null;
+  const volume24h = pickNumber(market, ['volume24h', 'volume24Hr', 'volume24hr', 'volume24Hours']);
+  const liquidity = pickNumber(market, ['liquidity', 'liquidity24h', 'marketMakerLiquidity']);
+
+  const rawStatus = pickString(market, ['status', 'state']);
+  const status = rawStatus ?? (typeof market.active === 'boolean' ? (market.active ? 'active' : 'inactive') : 'unknown');
+
+  const category = pickString(market, ['category']) ??
+    (Array.isArray(market.categories) && market.categories.length > 0 && typeof market.categories[0] === 'string'
+      ? (market.categories[0] as string)
+      : undefined);
+
+  const tokens = normalizeTokens(market);
+  const priceYes = tokens.find((token) => token.outcome === 'YES')?.price;
+  const priceNo = tokens.find((token) => token.outcome === 'NO')?.price;
+
+  return {
+    id: idValue,
+    title,
+    endDate,
+    volume24h,
+    liquidity,
+    status,
+    category: category ?? undefined,
+    tokens,
+    priceYes,
+    priceNo,
+  };
+};
+
+export const toQueryTokens = (query?: string): string[] => {
+  if (!query) {
+    return [];
+  }
+
+  return query
+    .split(/[\s,]+/u)
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+};
+
+export const matchesQuery = (market: GammaMarket, tokens: string[]): boolean => {
+  if (tokens.length === 0) {
+    return true;
+  }
+
+  const haystack = [
+    market.question,
+    market.description,
+    market.eventTitle,
+    market.title,
+  ]
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+    .map((value) => value.toLowerCase());
+
+  if (haystack.length === 0) {
+    return false;
+  }
+
+  return tokens.some((token) => haystack.some((value) => value.includes(token)));
+};
+
+export const sortMarkets = (markets: NormalizedMarket[], sort: 'volume24h' | 'liquidity' | 'endDate') => {
+  const sorter: Record<'volume24h' | 'liquidity' | 'endDate', (a: NormalizedMarket, b: NormalizedMarket) => number> = {
+    volume24h: (a, b) => b.volume24h - a.volume24h,
+    liquidity: (a, b) => b.liquidity - a.liquidity,
+    endDate: (a, b) => {
+      if (!a.endDate && !b.endDate) {
+        return 0;
+      }
+      if (!a.endDate) {
+        return 1;
+      }
+      if (!b.endDate) {
+        return -1;
+      }
+      return new Date(a.endDate).getTime() - new Date(b.endDate).getTime();
+    },
+  };
+
+  markets.sort(sorter[sort]);
+};

--- a/src/app/api/poly/market/route.ts
+++ b/src/app/api/poly/market/route.ts
@@ -1,0 +1,151 @@
+import { NextResponse } from 'next/server';
+
+import { fetchWithTimeout } from '@/lib/api';
+import { polyMarketQuerySchema } from '@/lib/validation';
+
+import { GammaMarket, NormalizedMarket, normalizeMarket } from '../helpers';
+
+const buildMetadata = (market: GammaMarket) => {
+  const metadata: Record<string, unknown> = {};
+
+  if (typeof market.description === 'string' && market.description.trim().length > 0) {
+    metadata.description = market.description.trim();
+  }
+
+  if (typeof market.eventTitle === 'string' && market.eventTitle.trim().length > 0) {
+    metadata.eventTitle = market.eventTitle.trim();
+  }
+
+  if (typeof market.image === 'string' && market.image.trim().length > 0) {
+    metadata.image = market.image.trim();
+  }
+
+  if (typeof market.resolution === 'string' && market.resolution.trim().length > 0) {
+    metadata.resolution = market.resolution.trim();
+  }
+
+  if (Array.isArray(market.categories)) {
+    const categories = market.categories.filter((value): value is string => typeof value === 'string' && value.length > 0);
+    if (categories.length > 0) {
+      metadata.categories = categories;
+    }
+  }
+
+  if ('liquidityHistory' in market && Array.isArray(market.liquidityHistory)) {
+    metadata.liquidityHistory = market.liquidityHistory;
+  }
+
+  return metadata;
+};
+
+const extractMarketPayload = (payload: unknown): GammaMarket | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  if ('market' in payload && (payload as { market?: unknown }).market) {
+    const market = (payload as { market: unknown }).market;
+    if (market && typeof market === 'object') {
+      return market as GammaMarket;
+    }
+  }
+
+  if ('data' in payload) {
+    const data = (payload as { data: unknown }).data;
+    if (Array.isArray(data) && data.length > 0) {
+      const [first] = data;
+      if (first && typeof first === 'object') {
+        return first as GammaMarket;
+      }
+    }
+    if (data && typeof data === 'object') {
+      return data as GammaMarket;
+    }
+  }
+
+  return payload as GammaMarket;
+};
+
+export async function GET(req: Request) {
+  const baseUrl = process.env.POLY_GAMMA_BASE;
+  if (!baseUrl) {
+    return NextResponse.json(
+      { status: 'error', message: 'POLY_GAMMA_BASE is not configured' },
+      { status: 500 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const rawParams = Object.fromEntries(url.searchParams.entries());
+  const parsed = polyMarketQuerySchema.safeParse(rawParams);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        status: 'error',
+        message: 'Invalid query parameters',
+        issues: parsed.error.flatten(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const { id } = parsed.data;
+  const targetUrl = `${baseUrl}/markets/${id}`;
+  const response = await fetchWithTimeout(targetUrl);
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    const message =
+      error instanceof Error && error.name === 'SyntaxError'
+        ? 'Invalid JSON response from Polymarket'
+        : (error as Error)?.message ?? 'Unable to parse response';
+
+    return NextResponse.json(
+      { status: 'error', message },
+      { status: 502 },
+    );
+  }
+
+  if (!response.ok) {
+    const status = response.status || 502;
+    const message =
+      payload && typeof payload === 'object' && 'message' in (payload as Record<string, unknown>)
+        ? String((payload as { message?: unknown }).message)
+        : 'Upstream request failed';
+
+    return NextResponse.json(
+      { status: 'error', message },
+      { status },
+    );
+  }
+
+  const marketPayload = extractMarketPayload(payload);
+
+  if (!marketPayload) {
+    return NextResponse.json(
+      { status: 'error', message: 'Market not found' },
+      { status: 404 },
+    );
+  }
+
+  const normalized = normalizeMarket(marketPayload);
+
+  if (!normalized) {
+    return NextResponse.json(
+      { status: 'error', message: 'Market not found' },
+      { status: 404 },
+    );
+  }
+
+  const metadata = buildMetadata(marketPayload);
+  const market: NormalizedMarket = normalized;
+
+  return NextResponse.json({
+    status: 'success',
+    market,
+    metadata,
+  });
+}

--- a/src/app/api/poly/route.ts
+++ b/src/app/api/poly/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server';
+
+import { fetchWithTimeout } from '@/lib/api';
+import { polyListQuerySchema } from '@/lib/validation';
+
+import {
+  GammaMarket,
+  NormalizedMarket,
+  matchesQuery,
+  normalizeMarket,
+  sortMarkets,
+  toQueryTokens,
+} from './helpers';
+
+type SortField = 'volume24h' | 'liquidity' | 'endDate';
+
+const clampLimit = (value: number) => Math.min(Math.max(value, 5), 200);
+
+export async function GET(req: Request) {
+  const baseUrl = process.env.POLY_GAMMA_BASE;
+  if (!baseUrl) {
+    return NextResponse.json(
+      { status: 'error', message: 'POLY_GAMMA_BASE is not configured' },
+      { status: 500 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const rawParams = Object.fromEntries(url.searchParams.entries());
+  const parsed = polyListQuerySchema.safeParse(rawParams);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        status: 'error',
+        message: 'Invalid query parameters',
+        issues: parsed.error.flatten(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const data = parsed.data;
+  const query = data.q?.trim();
+  const queryTokens = toQueryTokens(query);
+  const active = data.active ? data.active === 'true' : true;
+  const limit = clampLimit(data.limit ?? 30);
+  const category = data.category;
+  const sort = (data.sort ?? 'volume24h') as SortField;
+
+  const searchParams = new URLSearchParams({
+    active: String(active),
+    limit: String(limit),
+  });
+
+  if (category) {
+    searchParams.set('category', category);
+  }
+
+  const targetUrl = `${baseUrl}/markets?${searchParams.toString()}`;
+  const response = await fetchWithTimeout(targetUrl);
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    const message =
+      error instanceof Error && error.name === 'SyntaxError'
+        ? 'Invalid JSON response from Polymarket'
+        : (error as Error)?.message ?? 'Unable to parse response';
+
+    return NextResponse.json(
+      { status: 'error', message },
+      { status: 502 },
+    );
+  }
+
+  if (!response.ok) {
+    const status = response.status || 502;
+    const message =
+      payload && typeof payload === 'object' && 'message' in (payload as Record<string, unknown>)
+        ? String((payload as { message?: unknown }).message)
+        : 'Upstream request failed';
+
+    return NextResponse.json(
+      { status: 'error', message },
+      { status },
+    );
+  }
+
+  const upstreamMarkets = Array.isArray((payload as Record<string, unknown>).markets)
+    ? ((payload as { markets: unknown[] }).markets)
+    : Array.isArray((payload as Record<string, unknown>).data)
+      ? ((payload as { data: unknown[] }).data)
+      : [];
+
+  const filteredRaw = queryTokens.length === 0
+    ? upstreamMarkets
+    : upstreamMarkets.filter((market) => matchesQuery(market as GammaMarket, queryTokens));
+
+  const normalized = filteredRaw
+    .map((market) => normalizeMarket(market as GammaMarket))
+    .filter((market): market is NormalizedMarket => Boolean(market));
+
+  sortMarkets(normalized, sort);
+
+  return NextResponse.json({
+    status: 'success',
+    count: normalized.length,
+    markets: normalized,
+  });
+}

--- a/src/app/api/twitter/route.ts
+++ b/src/app/api/twitter/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  if (process.env.ENABLE_TWITTER !== '1') {
+    return NextResponse.json({
+      status: 'success',
+      comingSoon: true,
+      data: [],
+    });
+  }
+
+  return NextResponse.json({
+    status: 'success',
+    data: [],
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,13 @@
+import GdeltPanel from "@/components/dashboard/GdeltPanel";
+import PolymarketPanel from "@/components/dashboard/PolymarketPanel";
+import SearchStatePanel from "@/components/dashboard/SearchStatePanel";
+
 export default function HomePage() {
   return (
     <div className="grid grid-cols-1 gap-5 md:grid-cols-12">
-      {/* Placeholder tiles for upcoming dashboard sections */}
-      <div className="card md:col-span-8">Block A1</div>
-      <div className="card md:col-span-4">Block A2</div>
-      <div className="card md:col-span-6">Block B1</div>
-      <div className="card md:col-span-6">Block B2</div>
-      <div className="card md:col-span-12">Block C</div>
+      <PolymarketPanel />
+      <GdeltPanel />
+      <SearchStatePanel />
     </div>
   );
 }

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,14 +1,62 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
+import { useIsFetching, useQueryClient } from "@tanstack/react-query";
 
+import { SEARCH_SUBMIT_EVENT } from "@/components/search/events";
 import SearchBar from "./SearchBar";
+import { useGlobalFilters } from "@/stores/useGlobalFilters";
+
+const SEARCH_QUERY_PREFIXES = ["polyMarkets", "gdeltContext", "twitterSearch"] as const;
 
 export default function TopBar() {
-  const handleSearch = useCallback((keywords: string) => {
-    // TODO: hook into analytics pipeline
-    console.log("Search:", keywords);
-  }, []);
+  const queryClient = useQueryClient();
+  const datasets = useGlobalFilters((state) => state.datasets);
+
+  const activeFetches = useIsFetching({
+    predicate: (query) => {
+      const [prefix] = query.queryKey as [string | undefined];
+      return prefix !== undefined && SEARCH_QUERY_PREFIXES.includes(prefix as typeof SEARCH_QUERY_PREFIXES[number]);
+    },
+  });
+
+  const triggerRefetch = useCallback(() => {
+    const prefixes: Array<(typeof SEARCH_QUERY_PREFIXES)[number]> = [];
+
+    if (datasets.poly) {
+      prefixes.push("polyMarkets");
+    }
+
+    if (datasets.gdelt) {
+      prefixes.push("gdeltContext");
+    }
+
+    if (datasets.twitter) {
+      prefixes.push("twitterSearch");
+    }
+
+    if (prefixes.length === 0) {
+      return;
+    }
+
+    prefixes.forEach((prefix) => {
+      queryClient.invalidateQueries({ queryKey: [prefix] });
+      queryClient.refetchQueries({ queryKey: [prefix], type: "active" });
+    });
+  }, [datasets, queryClient]);
+
+  const handleSearch = useCallback(() => {
+    triggerRefetch();
+  }, [triggerRefetch]);
+
+  useEffect(() => {
+    const listener = () => {
+      triggerRefetch();
+    };
+
+    window.addEventListener(SEARCH_SUBMIT_EVENT, listener);
+    return () => window.removeEventListener(SEARCH_SUBMIT_EVENT, listener);
+  }, [triggerRefetch]);
 
   return (
     <div className="sticky top-[var(--header-h)] z-40 border-b border-[color:var(--border)]/60 bg-[color:var(--surface)]/85 backdrop-blur-md shadow-[0_10px_30px_rgba(0,0,0,0.35)]">
@@ -17,9 +65,9 @@ export default function TopBar() {
         <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(120%_60%_at_50%_-10%,rgba(224,36,36,0.15),transparent_60%)]" />
         <div className="relative mx-auto max-w-[1440px] px-5 py-4">
           <SearchBar
-            loading={false}
+            loading={activeFetches > 0}
             error={null}
-            onRetry={() => {}}
+            onRetry={() => triggerRefetch()}
             onSearch={handleSearch}
           />
         </div>

--- a/src/components/dashboard/GdeltPanel.tsx
+++ b/src/components/dashboard/GdeltPanel.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { useGlobalFilters } from "@/stores/useGlobalFilters";
+
+const MAX_RECORDS = 25;
+
+type GdeltResponse = Record<string, unknown>;
+
+type NormalizedStory = {
+  id: string;
+  title: string;
+  url?: string;
+  outlet?: string;
+  published?: string;
+};
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+function buildParams(keywords: string[], dateStart: string, dateEnd: string) {
+  const params = new URLSearchParams({
+    action: "context",
+    mode: "artlist",
+    format: "json",
+    date_start: dateStart,
+    date_end: dateEnd,
+    maxrecords: String(MAX_RECORDS),
+  });
+
+  if (keywords.length > 0) {
+    params.set("query", keywords.join(" OR "));
+  }
+
+  return params.toString();
+}
+
+async function fetchGdelt(params: string) {
+  const response = await fetch(`/api/gdelt?${params}`, { cache: "no-store" });
+  const data = (await response.json()) as GdeltResponse;
+
+  if (!response.ok) {
+    const message =
+      typeof data === "object" && data && "message" in data
+        ? String((data as { message?: unknown }).message ?? "Unable to load GDELT data")
+        : "Unable to load GDELT data";
+    throw new Error(message);
+  }
+
+  return data;
+}
+
+function toStoryId(candidate: unknown, fallback: string) {
+  if (typeof candidate === "string" && candidate.length > 0) {
+    return candidate;
+  }
+
+  return fallback;
+}
+
+function pickString(record: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeStories(payload: unknown): NormalizedStory[] {
+  const sourceArray: unknown[] = Array.isArray(payload)
+    ? payload
+    : Array.isArray((payload as Record<string, unknown>)?.articles)
+      ? (((payload as Record<string, unknown>).articles as unknown[]))
+      : Array.isArray((payload as Record<string, unknown>)?.artlist)
+        ? (((payload as Record<string, unknown>).artlist as unknown[]))
+        : Array.isArray((payload as Record<string, unknown>)?.results)
+          ? (((payload as Record<string, unknown>).results as unknown[]))
+          : [];
+
+  return sourceArray
+    .map((item, index) => {
+      if (!item || typeof item !== "object") {
+        return undefined;
+      }
+
+      const record = item as Record<string, unknown>;
+      const title =
+        pickString(record, [
+          "title",
+          "articleTitle",
+          "documentTitle",
+          "headline",
+          "transTitle",
+        ]) ?? "Untitled story";
+
+      const url = pickString(record, ["url", "docUrl", "articleUrl"]);
+      const outlet = pickString(record, ["source", "publisher", "domain", "sourceName"]);
+      const publishedRaw = pickString(record, ["date", "seendate", "published", "timestamp"]);
+
+      return {
+        id: toStoryId(url ?? pickString(record, ["guid", "id"]) ?? null, `gdelt-${index}`),
+        title,
+        url: url ?? undefined,
+        outlet: outlet ?? undefined,
+        published: publishedRaw ?? undefined,
+      } satisfies NormalizedStory;
+    })
+    .filter((story): story is NormalizedStory => Boolean(story));
+}
+
+function formatPublished(value?: string) {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = new Date(value);
+  if (!Number.isNaN(parsed.getTime())) {
+    return dateFormatter.format(parsed);
+  }
+
+  if (/^\d{8}/u.test(value)) {
+    const year = Number(value.slice(0, 4));
+    const month = Number(value.slice(4, 6)) - 1;
+    const day = Number(value.slice(6, 8));
+    const hours = Number(value.slice(9, 11) || 0);
+    const minutes = Number(value.slice(11, 13) || 0);
+    const fallback = new Date(Date.UTC(year, month, day, hours, minutes));
+    if (!Number.isNaN(fallback.getTime())) {
+      return dateFormatter.format(fallback);
+    }
+  }
+
+  return value;
+}
+
+export default function GdeltPanel() {
+  const keywords = useGlobalFilters((state) => state.keywords);
+  const datasets = useGlobalFilters((state) => state.datasets);
+  const dateStart = useGlobalFilters((state) => state.dateStart);
+  const dateEnd = useGlobalFilters((state) => state.dateEnd);
+
+  const queryParams = useMemo(
+    () => buildParams(keywords, dateStart, dateEnd),
+    [keywords, dateStart, dateEnd]
+  );
+
+  const shouldFetch = datasets.gdelt && keywords.length > 0;
+
+  const { data, error, isFetching, isPending } = useQuery({
+    queryKey: ["gdeltContext", { queryParams }],
+    queryFn: () => fetchGdelt(queryParams),
+    enabled: shouldFetch,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
+
+  const loading = isFetching || isPending;
+  const stories = useMemo(() => (data ? normalizeStories(data) : []), [data]);
+
+  return (
+    <section className="card md:col-span-4">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-[color:var(--text)]">News pulse</h2>
+          <p className="text-sm text-[color:var(--muted)]">
+            {keywords.length > 0
+              ? "Latest coverage sourced from GDELT"
+              : "Enter keywords to pull related coverage"}
+          </p>
+        </div>
+        {loading && (
+          <span className="flex items-center gap-2 text-xs uppercase tracking-wide text-[color:var(--muted)]">
+            <span className="h-2 w-2 animate-ping rounded-full bg-[color:var(--primary)]" aria-hidden />
+            Loading…
+          </span>
+        )}
+      </header>
+
+      {!datasets.gdelt ? (
+        <div className="mt-4 rounded-xl border border-dashed border-[color:var(--border)]/80 bg-[color:var(--surface-2)]/40 p-6 text-center text-sm text-[color:var(--muted)]">
+          Enable the GDELT dataset to surface recent coverage.
+        </div>
+      ) : keywords.length === 0 ? (
+        <div className="mt-4 rounded-xl border border-dashed border-[color:var(--border)]/80 bg-[color:var(--surface-2)]/40 p-6 text-center text-sm text-[color:var(--muted)]">
+          Start typing in the search bar and press Enter to fetch matching articles.
+        </div>
+      ) : error ? (
+        <div className="mt-4 rounded-xl border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-100">
+          {(error as Error).message}
+        </div>
+      ) : stories.length === 0 && !loading ? (
+        <div className="mt-4 rounded-xl border border-dashed border-[color:var(--border)]/80 bg-[color:var(--surface-2)]/40 p-6 text-center text-sm text-[color:var(--muted)]">
+          No recent coverage found for the current filters.
+        </div>
+      ) : (
+        <ul className="mt-4 space-y-3">
+          {stories.slice(0, 10).map((story) => {
+            const published = formatPublished(story.published);
+
+            return (
+              <li
+                key={story.id}
+                className="rounded-2xl border border-[color:var(--border)]/80 bg-[color:var(--surface-2)]/60 p-4 text-sm shadow-sm transition hover:border-[color:var(--primary)]/35"
+              >
+                <div className="flex flex-col gap-2">
+                  {story.url ? (
+                    <a
+                      href={story.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-base font-semibold text-[color:var(--text)] transition hover:text-[color:var(--primary)]"
+                    >
+                      {story.title}
+                    </a>
+                  ) : (
+                    <span className="text-base font-semibold text-[color:var(--text)]">{story.title}</span>
+                  )}
+                  <div className="flex flex-wrap items-center gap-3 text-xs text-[color:var(--muted)]">
+                    {story.outlet && <span>{story.outlet}</span>}
+                    {published && <span>{published}</span>}
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/dashboard/PolymarketPanel.tsx
+++ b/src/components/dashboard/PolymarketPanel.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import type { NormalizedMarket } from "@/app/api/poly/helpers";
+import { useGlobalFilters } from "@/stores/useGlobalFilters";
+
+const DEFAULT_LIMIT = 40;
+
+const numberFormatter = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+const priceFormatter = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  maximumFractionDigits: 1,
+});
+
+type PolyResponse = {
+  status: "success" | "error";
+  message?: string;
+  count?: number;
+  markets?: NormalizedMarket[];
+};
+
+function buildQueryParams(keywords: string[]) {
+  const params = new URLSearchParams({
+    active: "true",
+    limit: String(DEFAULT_LIMIT),
+  });
+
+  if (keywords.length > 0) {
+    params.set("q", keywords.join(" "));
+  }
+
+  return params.toString();
+}
+
+async function fetchPolyMarkets(params: string) {
+  const response = await fetch(`/api/poly?${params}`, { cache: "no-store" });
+  const data = (await response.json()) as PolyResponse;
+
+  if (!response.ok || data.status === "error") {
+    const message = data.message ?? "Unable to load Polymarket data";
+    throw new Error(message);
+  }
+
+  return {
+    count: data.count ?? data.markets?.length ?? 0,
+    markets: data.markets ?? [],
+  };
+}
+
+function resolvePrice(value?: number) {
+  if (value === undefined || Number.isNaN(value)) {
+    return "--";
+  }
+
+  if (value <= 1) {
+    return priceFormatter.format(value);
+  }
+
+  return Number.isFinite(value) ? `$${value.toFixed(2)}` : "--";
+}
+
+export default function PolymarketPanel() {
+  const keywords = useGlobalFilters((state) => state.keywords);
+  const datasets = useGlobalFilters((state) => state.datasets);
+
+  const queryParams = useMemo(() => buildQueryParams(keywords), [keywords]);
+
+  const { data, error, isPending, isFetching } = useQuery({
+    queryKey: ["polyMarkets", { queryParams }],
+    queryFn: () => fetchPolyMarkets(queryParams),
+    enabled: datasets.poly,
+    staleTime: 30_000,
+    gcTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+
+  const loading = isPending || isFetching;
+
+  if (!datasets.poly) {
+    return (
+      <section className="card md:col-span-8">
+        <header className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-[color:var(--text)]">Polymarket markets</h2>
+            <p className="text-sm text-[color:var(--muted)]">
+              Enable the Polymarket dataset from the search bar to see results.
+            </p>
+          </div>
+        </header>
+      </section>
+    );
+  }
+
+  const markets = data?.markets ?? [];
+  const resultCount = data?.count ?? markets.length;
+
+  return (
+    <section className="card md:col-span-8">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-[color:var(--text)]">Polymarket markets</h2>
+          <p className="text-sm text-[color:var(--muted)]">
+            {keywords.length > 0
+              ? `Showing matches for “${keywords.join(" ")}”`
+              : "Trending markets from Polymarket Gamma"}
+          </p>
+        </div>
+        <div className="flex items-center gap-3 text-xs uppercase tracking-wide text-[color:var(--muted)]">
+          {!loading && (
+            <span className="rounded-full border border-white/5 bg-white/5 px-2 py-0.5 text-[10px] font-semibold text-[color:var(--text)]/80">
+              {resultCount} result{resultCount === 1 ? "" : "s"}
+            </span>
+          )}
+          {loading && (
+            <span className="flex items-center gap-2">
+              <span className="h-2 w-2 animate-ping rounded-full bg-[color:var(--primary)]" aria-hidden />
+              Loading…
+            </span>
+          )}
+        </div>
+      </header>
+
+      {error ? (
+        <div className="mt-4 rounded-xl border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-100">
+          {(error as Error).message}
+        </div>
+      ) : markets.length === 0 && !loading ? (
+        <div className="mt-4 rounded-xl border border-dashed border-[color:var(--border)]/80 bg-[color:var(--surface-2)]/40 p-6 text-center text-sm text-[color:var(--muted)]">
+          No markets found. Try adjusting your keywords or clearing filters.
+        </div>
+      ) : (
+        <ul className="mt-4 space-y-3">
+          {markets.slice(0, 12).map((market) => {
+            const yesPrice = resolvePrice(market.priceYes);
+            const noPrice = resolvePrice(market.priceNo);
+            const parsedEnd = market.endDate ? new Date(market.endDate) : null;
+            const endLabel =
+              parsedEnd && !Number.isNaN(parsedEnd.getTime())
+                ? parsedEnd.toLocaleString()
+                : market.endDate ?? undefined;
+
+            return (
+              <li
+                key={market.id}
+                className="rounded-2xl border border-[color:var(--border)]/80 bg-[color:var(--surface-2)]/60 p-4 shadow-sm transition hover:border-[color:var(--primary)]/35"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <h3 className="text-base font-semibold text-[color:var(--text)]">{market.title}</h3>
+                    <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-[color:var(--muted)]">
+                      {market.category && (
+                        <span className="rounded-full border border-white/5 bg-white/5 px-2 py-0.5 text-[11px] uppercase tracking-wide">
+                          {market.category}
+                        </span>
+                      )}
+                      {endLabel && <span>Ends {endLabel}</span>}
+                      <span>24h vol {numberFormatter.format(market.volume24h)}</span>
+                      <span>Liquidity {numberFormatter.format(market.liquidity)}</span>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3 text-sm">
+                    <div className="text-right">
+                      <span className="block text-xs uppercase tracking-wide text-[color:var(--muted)]">YES</span>
+                      <span className="text-base font-semibold text-[color:var(--text)]">{yesPrice}</span>
+                    </div>
+                    <div className="text-right">
+                      <span className="block text-xs uppercase tracking-wide text-[color:var(--muted)]">NO</span>
+                      <span className="text-base font-semibold text-[color:var(--text)]">{noPrice}</span>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/dashboard/SearchStatePanel.tsx
+++ b/src/components/dashboard/SearchStatePanel.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useCallback } from "react";
+
+import { SEARCH_SUBMIT_EVENT } from "@/components/search/events";
+import { useGlobalFilters } from "@/stores/useGlobalFilters";
+
+const datasetLabels: Record<"gdelt" | "poly" | "twitter", string> = {
+  gdelt: "GDELT",
+  poly: "Polymarket",
+  twitter: "Twitter",
+};
+
+function dispatchSearchEvent(keywords: string[]) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(
+    new CustomEvent(SEARCH_SUBMIT_EVENT, {
+      detail: { keywords },
+    })
+  );
+}
+
+export default function SearchStatePanel() {
+  const keywords = useGlobalFilters((state) => state.keywords);
+  const dateStart = useGlobalFilters((state) => state.dateStart);
+  const dateEnd = useGlobalFilters((state) => state.dateEnd);
+  const activePreset = useGlobalFilters((state) => state.activePreset);
+  const datasets = useGlobalFilters((state) => state.datasets);
+  const setKeywords = useGlobalFilters((state) => state.setKeywords);
+
+  const handleClear = useCallback(() => {
+    setKeywords([]);
+    dispatchSearchEvent([]);
+  }, [setKeywords]);
+
+  const activeDatasets = Object.entries(datasets)
+    .filter(([, enabled]) => enabled)
+    .map(([key]) => datasetLabels[key as keyof typeof datasetLabels])
+    .filter(Boolean);
+
+  return (
+    <section className="card md:col-span-12">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-[color:var(--text)]">Active filters</h2>
+          <p className="text-sm text-[color:var(--muted)]">
+            Monitor search state and tweak datasets while exploring the dashboard.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleClear}
+          disabled={keywords.length === 0}
+          className="rounded-full border border-[color:var(--border)]/80 px-4 py-1 text-xs uppercase tracking-wide text-[color:var(--muted)] transition hover:border-[color:var(--primary)]/45 hover:text-[color:var(--text)] disabled:cursor-not-allowed disabled:border-[color:var(--border)]/40 disabled:text-[color:var(--muted)]/60"
+        >
+          Clear search
+        </button>
+      </div>
+
+      <div className="mt-4 grid gap-4 md:grid-cols-3">
+        <div className="rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--surface-2)]/60 p-4">
+          <h3 className="text-xs uppercase tracking-wide text-[color:var(--muted)]">Keywords</h3>
+          {keywords.length > 0 ? (
+            <div className="mt-2 flex flex-wrap gap-2">
+              {keywords.map((keyword) => (
+                <span
+                  key={keyword}
+                  className="rounded-full border border-[color:var(--primary)]/40 bg-[color:var(--primary)]/15 px-3 py-1 text-sm text-[color:var(--text)]"
+                >
+                  {keyword}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <p className="mt-2 text-sm text-[color:var(--muted)]">No keywords applied.</p>
+          )}
+        </div>
+
+        <div className="rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--surface-2)]/60 p-4">
+          <h3 className="text-xs uppercase tracking-wide text-[color:var(--muted)]">Date range</h3>
+          <p className="mt-2 text-sm text-[color:var(--text)]">
+            {dateStart} → {dateEnd}
+          </p>
+          <p className="text-xs uppercase tracking-wide text-[color:var(--muted)]">Preset: {activePreset}</p>
+        </div>
+
+        <div className="rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--surface-2)]/60 p-4">
+          <h3 className="text-xs uppercase tracking-wide text-[color:var(--muted)]">Datasets</h3>
+          {activeDatasets.length > 0 ? (
+            <div className="mt-2 flex flex-wrap gap-2">
+              {activeDatasets.map((dataset) => (
+                <span
+                  key={dataset}
+                  className="rounded-full border border-white/5 bg-white/5 px-3 py-1 text-sm text-[color:var(--text)]"
+                >
+                  {dataset}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <p className="mt-2 text-sm text-[color:var(--muted)]">All datasets disabled.</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,61 @@
+export type FetchOptions = RequestInit;
+
+const DEFAULT_TIMEOUT = 10000;
+
+export async function fetchWithTimeout(
+  url: string,
+  options: FetchOptions = {},
+  timeout = DEFAULT_TIMEOUT,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      let message = response.statusText || 'Request failed';
+
+      try {
+        const data = await response.clone().json();
+        if (typeof data === 'object' && data && 'message' in data) {
+          message = String((data as { message?: unknown }).message ?? message);
+        }
+      } catch (error) {
+        if (error instanceof Error && error.name !== 'SyntaxError') {
+          message = error.message;
+        }
+      }
+
+      return new Response(
+        JSON.stringify({ status: 'error', message }),
+        {
+          status: response.status,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    return response;
+  } catch (error) {
+    const isAbortError = error instanceof Error && error.name === 'AbortError';
+    const message = isAbortError
+      ? 'Request timed out'
+      : error instanceof Error
+        ? error.message
+        : 'Request failed';
+
+    return new Response(
+      JSON.stringify({ status: 'error', message }),
+      {
+        status: isAbortError ? 504 : 500,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const yyyymmddSchema = z
+  .string()
+  .regex(/^[0-9]{8}$/u, 'Expected YYYYMMDD format');
+
+export const gdeltQuerySchema = z
+  .object({
+    action: z.string().optional(),
+    date_start: yyyymmddSchema.optional(),
+    date_end: yyyymmddSchema.optional(),
+  })
+  .passthrough();
+
+const booleanLiteralSchema = z.union([z.literal('true'), z.literal('false')]);
+
+export const polyListQuerySchema = z
+  .object({
+    q: z.string().trim().min(1).optional(),
+    active: booleanLiteralSchema.optional(),
+    limit: z.coerce.number().int().optional(),
+    category: z.string().trim().min(1).optional(),
+    sort: z.enum(['volume24h', 'liquidity', 'endDate']).optional(),
+  })
+  .passthrough();
+
+export const polyMarketQuerySchema = z.object({
+  id: z.string().min(1, 'Market id is required'),
+});


### PR DESCRIPTION
## Summary
- add shared fetch helper and validation schemas for API proxies
- implement GDELT and Polymarket (list/detail) proxy routes with normalization and guards
- stub the Twitter API endpoint behind an environment flag

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd9aff58d883289315a0b891d62d55