### PR TITLE
Fix search bar keyword mirroring effect

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -56,10 +56,8 @@ export default function SearchBar({
 
   useEffect(() => {
     const joined = keywords.join(" ");
-    if (joined !== query) {
-      setQuery(joined);
-    }
-  }, [keywords, query]);
+    setQuery((current) => (current === joined ? current : joined));
+  }, [keywords]);
 
   useEffect(() => {
     const handle = window.setTimeout(() => {


### PR DESCRIPTION
## Summary
- prevent the search bar keyword mirror effect from re-running on local query updates by guarding the state setter

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dda28b000c832883ea4f2712eb0501