### PR TITLE
feat: add GDELT and PolyMarket query hooks

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
+  roots: ["<rootDir>/src"],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "poly",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-toast": "^1.2.15",
         "@radix-ui/react-tooltip": "^1.2.8",
@@ -1645,6 +1647,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -1658,6 +1666,36 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2037,6 +2075,49 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -2227,6 +2308,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-toast": "^1.2.15",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.62.9",
+        "@tanstack/react-virtual": "^3.13.12",
         "clsx": "^2.1.1",
         "framer-motion": "^11.11.17",
         "lucide-react": "^0.474.0",
@@ -2383,6 +2384,33 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,15 +28,18 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.1.0",
+        "@types/jest": "^29.5.12",
         "@types/node": "20.17.10",
         "@types/react": "18.3.12",
         "@types/react-dom": "18.3.1",
         "autoprefixer": "10.4.20",
         "eslint": "8.57.1",
         "eslint-config-next": "14.2.15",
+        "jest": "^29.7.0",
         "postcss": "8.4.49",
         "shadcn-ui": "^0.9.5",
         "tailwindcss": "3.4.17",
+        "ts-jest": "^29.2.5",
         "typescript": "5.6.3"
       }
     },
@@ -52,6 +55,490 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
@@ -60,6 +547,61 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@date-fns/tz": {
       "version": "1.4.1",
@@ -328,6 +870,505 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/core/node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -335,6 +1376,17 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -1187,6 +2239,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -1238,6 +2317,51 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/d3-array": {
@@ -1303,6 +2427,54 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -1347,6 +2519,30 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.45.0",
@@ -1935,6 +3131,35 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2264,6 +3489,132 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2349,6 +3700,36 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -2420,6 +3801,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -2466,6 +3857,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -2502,11 +3903,89 @@
         "node": ">= 6"
       }
     },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -2516,6 +3995,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2550,6 +4047,103 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2805,12 +4399,37 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/dedent": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
+      "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -2848,6 +4467,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -2859,6 +4488,16 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -2917,11 +4556,34 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -3549,6 +5211,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -3600,6 +5276,63 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3666,6 +5399,16 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
       }
     },
     "node_modules/file-entry-cache": {
@@ -3876,6 +5619,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3910,6 +5673,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -3922,6 +5695,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -4072,6 +5858,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -4165,6 +5973,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4187,6 +6012,26 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4262,6 +6107,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -4435,6 +6287,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -4577,6 +6439,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -4687,6 +6562,77 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4723,6 +6669,643 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-cli/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-cli/node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -4751,10 +7334,30 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4811,6 +7414,16 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
@@ -4829,6 +7442,16 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -4885,6 +7508,13 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4919,6 +7549,39 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4928,6 +7591,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4949,6 +7619,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimatch": {
@@ -5057,6 +7737,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/next": {
       "version": "14.2.15",
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.15.tgz",
@@ -5135,6 +7822,13 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
@@ -5159,6 +7853,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/object-assign": {
@@ -5302,6 +8009,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5370,6 +8093,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5381,6 +8114,25 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -5468,6 +8220,75 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5604,6 +8425,55 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5624,6 +8494,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -5900,6 +8787,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -5920,6 +8817,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-cwd/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5938,6 +8858,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/reusify": {
@@ -6273,6 +9203,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6282,12 +9239,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -6309,6 +9307,20 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/string-width": {
@@ -6524,6 +9536,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -6698,6 +9720,43 @@
         }
       }
     },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -6780,6 +9839,13 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6811,6 +9877,85 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.4.tgz",
+      "integrity": "sha512-ccVcRABct5ZELCT5U0+DZwkXMCcOCLi2doHRrKy1nK/s7J7bch6TzJMsrY09WxgUUIP/ITfmcDS8D2yl63rnXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.2",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -6841,6 +9986,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -6946,6 +10101,20 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -7108,6 +10277,21 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/victory-vendor": {
       "version": "36.9.2",
       "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
@@ -7128,6 +10312,16 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
       }
     },
     "node_modules/which": {
@@ -7244,6 +10438,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -7345,6 +10546,44 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
@@ -7355,6 +10594,57 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-toast": "^1.2.15",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.62.9",
@@ -1764,6 +1765,21 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-dismissable-layer": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
@@ -1989,6 +2005,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -2003,6 +2050,36 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "test": "jest"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.62.9",
+    "@tanstack/react-virtual": "^3.13.12",
     "clsx": "^2.1.1",
     "framer-motion": "^11.11.17",
     "lucide-react": "^0.474.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "jest"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -29,13 +30,16 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.1.0",
+    "@types/jest": "^29.5.12",
     "@types/node": "20.17.10",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "autoprefixer": "10.4.20",
     "eslint": "8.57.1",
     "eslint-config-next": "14.2.15",
+    "jest": "^29.7.0",
     "postcss": "8.4.49",
+    "ts-jest": "^29.2.5",
     "shadcn-ui": "^0.9.5",
     "tailwindcss": "3.4.17",
     "typescript": "5.6.3"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.62.9",
@@ -39,9 +40,9 @@
     "eslint-config-next": "14.2.15",
     "jest": "^29.7.0",
     "postcss": "8.4.49",
-    "ts-jest": "^29.2.5",
     "shadcn-ui": "^0.9.5",
     "tailwindcss": "3.4.17",
+    "ts-jest": "^29.2.5",
     "typescript": "5.6.3"
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { Toaster } from "@/components/ui/toaster";
 import "./globals.css";
 import TopBar from "@/components/TopBar";
+import { SidePanel } from "@/components/shared/SidePanel";
 import { AppQueryProvider } from "./query-client-provider";
 
 const poppins = Poppins({
@@ -63,6 +64,7 @@ export default function RootLayout({
               </div>
             </footer>
           </div>
+          <SidePanel />
           <Toaster />
         </AppQueryProvider>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import type { Metadata } from "next";
 import { Poppins } from "next/font/google";
 
@@ -41,15 +42,15 @@ export default function RootLayout({
               <div className="mx-auto flex h-[72px] w-full max-w-none items-center justify-between px-5">
                 <span className="text-lg font-bold tracking-tight">Poly</span>
                 <nav className="flex items-center gap-6 text-sm text-muted">
-                  <a className="transition hover:text-text" href="#">
+                  <Link className="transition hover:text-text" href="/">
                     Overview
-                  </a>
-                  <a className="transition hover:text-text" href="#">
+                  </Link>
+                  <Link className="transition hover:text-text" href="/reports">
                     Reports
-                  </a>
-                  <a className="transition hover:text-text" href="#">
+                  </Link>
+                  <Link className="transition hover:text-text" href="/settings">
                     Settings
-                  </a>
+                  </Link>
                 </nav>
               </div>
             </header>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,659 @@
-import GdeltPanel from "@/components/dashboard/GdeltPanel";
-import PolymarketPanel from "@/components/dashboard/PolymarketPanel";
-import SearchStatePanel from "@/components/dashboard/SearchStatePanel";
+'use client';
+
+import { useMemo, useState, type ComponentProps } from "react";
+
+import { GdeltChart } from "@/components/gdelt/GdeltChart";
+import { GdeltEventsList } from "@/components/gdelt/GdeltEventsList";
+import { InsightsPanel } from "@/components/gdelt/InsightsPanel";
+import { KpiCards } from "@/components/gdelt/KpiCards";
+import { PolyMarketGrid } from "@/components/poly/PolyMarketGrid";
+import ActivityPanel from "@/components/system/ActivityPanel";
+import { TwitterPlaceholder } from "@/components/twitter/TwitterPlaceholder";
+import { useGdeltBBVA } from "@/hooks/useGdeltBBVA";
+import { useGdeltBilateral } from "@/hooks/useGdeltBilateral";
+import { useGdeltContext } from "@/hooks/useGdeltContext";
+import { useGdeltCountry } from "@/hooks/useGdeltCountry";
+import { usePolySearch } from "@/hooks/usePolySearch";
+import { normalizeGdeltDate } from "@/hooks/utils";
+import { useGlobalFilters } from "@/stores/useGlobalFilters";
+import { useGdeltMode } from "@/stores/useGdeltMode";
+import { useSidePanel } from "@/stores/useSidePanel";
+import type { GdeltEvent, GdeltInsights, GdeltSeriesPoint } from "@/types";
+
+type ActivityPanelProps = ComponentProps<typeof ActivityPanel>;
+type DatasetStatusEntry = NonNullable<ActivityPanelProps["datasets"]>[number];
+type RecentQueryEntry = NonNullable<ActivityPanelProps["recentQueries"]>[number];
+
+type Aggregation = "daily" | "monthly";
+
+interface ActiveGdeltData {
+  series: GdeltSeriesPoint[];
+  events: GdeltEvent[];
+  insights?: GdeltInsights;
+  aggregation: Aggregation;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const toRecordArray = (value: unknown): Record<string, unknown>[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is Record<string, unknown> => isRecord(item));
+};
+
+const toNumber = (value: unknown): number | undefined => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  return undefined;
+};
+
+const extractGdeltItems = (payload: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(payload)) {
+    return toRecordArray(payload);
+  }
+
+  if (!isRecord(payload)) {
+    return [];
+  }
+
+  if (Array.isArray(payload.data)) {
+    return toRecordArray(payload.data);
+  }
+
+  if (Array.isArray(payload.results)) {
+    return toRecordArray(payload.results);
+  }
+
+  if (Array.isArray(payload.series)) {
+    return toRecordArray(payload.series);
+  }
+
+  if (Array.isArray(payload.events)) {
+    return toRecordArray(payload.events);
+  }
+
+  return [];
+};
+
+const toSeriesPoint = (record: Record<string, unknown>): GdeltSeriesPoint => {
+  const dateCandidate =
+    record.DayDate ?? record.SQLDATE ?? record.date ?? record.day ?? record.timestamp ?? "";
+
+  const point: GdeltSeriesPoint = {
+    date: normalizeGdeltDate(dateCandidate),
+  };
+
+  const conflictCandidate =
+    record.conflict_events ?? record.total_events ?? record.count ?? record.value;
+  const sentimentCandidate =
+    record.avg_sentiment ?? record.average_sentiment ?? record.sentiment ?? record.avgTone;
+  const impactCandidate = record.avg_impact ?? record.average_impact ?? record.impact;
+  const interactionCandidate =
+    record.interaction_count ?? record.interactions ?? record.total_interactions;
+  const coverageCandidate =
+    record.relative_coverage ?? record.coverage ?? record.relative ?? record.relativeCoverage;
+
+  const conflictEvents = toNumber(conflictCandidate);
+  const avgSentiment = toNumber(sentimentCandidate);
+  const avgImpact = toNumber(impactCandidate);
+  const interactionCount = toNumber(interactionCandidate);
+  const relativeCoverage = toNumber(coverageCandidate);
+
+  if (conflictEvents !== undefined) {
+    point.conflict_events = conflictEvents;
+  }
+
+  if (avgSentiment !== undefined) {
+    point.avg_sentiment = avgSentiment;
+  }
+
+  if (avgImpact !== undefined) {
+    point.avg_impact = avgImpact;
+  }
+
+  if (interactionCount !== undefined) {
+    point.interaction_count = interactionCount;
+  }
+
+  if (relativeCoverage !== undefined) {
+    point.relative_coverage = relativeCoverage;
+  }
+
+  return point;
+};
+
+const toEvent = (record: Record<string, unknown>): GdeltEvent => {
+  const base: GdeltEvent = {
+    ...record,
+    SQLDATE: (record.SQLDATE ?? record.DayDate ?? record.date ?? "") as string | number,
+    SOURCEURL: typeof record.SOURCEURL === "string" ? record.SOURCEURL : "",
+    Actor1CountryCode:
+      typeof record.Actor1CountryCode === "string" ? record.Actor1CountryCode : undefined,
+    Actor2CountryCode:
+      typeof record.Actor2CountryCode === "string" ? record.Actor2CountryCode : undefined,
+    EventCode: typeof record.EventCode === "string" ? record.EventCode : undefined,
+    AvgTone: toNumber(record.AvgTone),
+  };
+
+  return base;
+};
+
+const average = (values: Array<number | undefined>): number | undefined => {
+  const filtered = values.filter((value): value is number => typeof value === "number");
+  if (filtered.length === 0) {
+    return undefined;
+  }
+  const total = filtered.reduce((sum, value) => sum + value, 0);
+  return total / filtered.length;
+};
+
+const topPairFromInsights = (insights?: GdeltInsights): string | undefined => {
+  if (!insights) {
+    return undefined;
+  }
+
+  const record = insights as Record<string, unknown>;
+
+  const direct = record.top_pair;
+  if (typeof direct === "string") {
+    return direct;
+  }
+
+  const pairsCandidate = record.top_pairs ?? record.actor_pairs ?? record.leading_pairs;
+  if (Array.isArray(pairsCandidate)) {
+    const first = pairsCandidate[0];
+    if (typeof first === "string") {
+      return first;
+    }
+    if (isRecord(first)) {
+      const label =
+        typeof first.label === "string"
+          ? first.label
+          : typeof first.pair === "string"
+          ? first.pair
+          : typeof first.name === "string"
+          ? first.name
+          : undefined;
+      if (label) {
+        return label;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const toIsoString = (timestamp?: number): string | undefined => {
+  if (!timestamp) {
+    return undefined;
+  }
+
+  if (timestamp <= 0) {
+    return undefined;
+  }
+
+  return new Date(timestamp).toISOString();
+};
+
+const DisabledDatasetCard = ({ title, description }: { title: string; description: string }) => (
+  <div className="flex h-full min-h-[200px] flex-col items-center justify-center rounded-3xl border border-dashed border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/40 p-6 text-center">
+    <h3 className="text-base font-semibold text-[color:var(--text)]">{title}</h3>
+    <p className="mt-2 text-sm text-[color:var(--muted)]">{description}</p>
+  </div>
+);
+
+interface QueryState {
+  dataUpdatedAt: number;
+  isError: boolean;
+  isLoading: boolean;
+  isFetching: boolean;
+  error: unknown;
+}
 
 export default function HomePage() {
+  const keywords = useGlobalFilters((state) => state.keywords);
+  const dateStart = useGlobalFilters((state) => state.dateStart);
+  const dateEnd = useGlobalFilters((state) => state.dateEnd);
+  const datasets = useGlobalFilters((state) => state.datasets);
+  const mode = useGdeltMode((state) => state.mode);
+  const modeParams = useGdeltMode((state) => state.params);
+  const openPanel = useSidePanel((state) => state.openPanel);
+
+  const [activeDate, setActiveDate] = useState<string | null>(null);
+
+  const contextParams = modeParams.context ?? { includeInsights: true, limit: 500 };
+  const countryParams = modeParams.country ?? { country: "" };
+  const bilateralParams = modeParams.bilateral ?? { country1: "", country2: "" };
+  const bbvaParams =
+    modeParams.bbva ?? ({ actor1: "", actor2: "", includeTotal: false } as const);
+
+  const contextQuery = useGdeltContext(
+    mode === "context" && datasets.gdelt
+      ? {
+          includeInsights: contextParams.includeInsights,
+          limit: contextParams.limit,
+        }
+      : {
+          dateStart: "",
+          dateEnd: "",
+        },
+  );
+
+  const countryQuery = useGdeltCountry(
+    mode === "country" && datasets.gdelt
+      ? {
+          country: countryParams.country,
+          dateStart,
+          dateEnd,
+        }
+      : {
+          country: "",
+          dateStart: "",
+          dateEnd: "",
+        },
+  );
+
+  const bilateralQuery = useGdeltBilateral(
+    mode === "bilateral" && datasets.gdelt
+      ? {
+          country1: bilateralParams.country1,
+          country2: bilateralParams.country2,
+          dateStart,
+          dateEnd,
+        }
+      : {
+          country1: "",
+          country2: "",
+          dateStart: "",
+          dateEnd: "",
+        },
+  );
+
+  const bbvaQuery = useGdeltBBVA(
+    mode === "bbva" && datasets.gdelt
+      ? {
+          actor1: bbvaParams.actor1,
+          actor2: bbvaParams.actor2,
+          dateStart,
+          dateEnd,
+          includeTotal: bbvaParams.includeTotal,
+          cameoCodes: bbvaParams.cameoCodes,
+        }
+      : {
+          actor1: "",
+          actor2: "",
+          dateStart: "",
+          dateEnd: "",
+        },
+  );
+
+  const polyQuery = usePolySearch(
+    datasets.poly
+      ? {
+          q: keywords.join(" "),
+          active: true,
+          sort: "volume24h",
+        }
+      : { q: "" },
+  );
+
+  const activeGdeltState: QueryState = (() => {
+    if (!datasets.gdelt) {
+      return { dataUpdatedAt: 0, isError: false, isLoading: false, isFetching: false, error: null };
+    }
+
+    switch (mode) {
+      case "country":
+        return {
+          dataUpdatedAt: countryQuery.dataUpdatedAt,
+          isError: countryQuery.isError,
+          isLoading: countryQuery.isLoading,
+          isFetching: countryQuery.isFetching,
+          error: countryQuery.error,
+        };
+      case "bilateral":
+        return {
+          dataUpdatedAt: bilateralQuery.dataUpdatedAt,
+          isError: bilateralQuery.isError,
+          isLoading: bilateralQuery.isLoading,
+          isFetching: bilateralQuery.isFetching,
+          error: bilateralQuery.error,
+        };
+      case "bbva":
+        return {
+          dataUpdatedAt: bbvaQuery.dataUpdatedAt,
+          isError: bbvaQuery.isError,
+          isLoading: bbvaQuery.isLoading,
+          isFetching: bbvaQuery.isFetching,
+          error: bbvaQuery.error,
+        };
+      default:
+        return {
+          dataUpdatedAt: contextQuery.dataUpdatedAt,
+          isError: contextQuery.isError,
+          isLoading: contextQuery.isLoading,
+          isFetching: contextQuery.isFetching,
+          error: contextQuery.error,
+        };
+    }
+  })();
+
+  const activeGdeltData = useMemo<ActiveGdeltData>(() => {
+    if (!datasets.gdelt) {
+      return { series: [], events: [], aggregation: "daily" };
+    }
+
+    if (mode === "context") {
+      return {
+        series: contextQuery.data?.series ?? [],
+        events: contextQuery.data?.events ?? [],
+        insights: contextQuery.data?.insights,
+        aggregation: "daily",
+      };
+    }
+
+    const rawData =
+      mode === "country"
+        ? countryQuery.data
+        : mode === "bilateral"
+        ? bilateralQuery.data
+        : bbvaQuery.data;
+
+    const items = extractGdeltItems(rawData);
+    const series = items.map(toSeriesPoint);
+    const events = items.map(toEvent);
+
+    let insights: GdeltInsights | undefined;
+    let aggregation: Aggregation = "daily";
+
+    if (isRecord(rawData)) {
+      const rawInsights = rawData["insights"];
+      if (rawInsights && typeof rawInsights === "object") {
+        insights = rawInsights as GdeltInsights;
+      }
+
+      const aggregationCandidate =
+        rawData["aggregation"] ?? rawData["granularity"] ?? rawData["time_unit"];
+      if (
+        typeof aggregationCandidate === "string" &&
+        aggregationCandidate.toLowerCase().includes("month")
+      ) {
+        aggregation = "monthly";
+      }
+    }
+
+    return { series, events, insights, aggregation };
+  }, [
+    datasets.gdelt,
+    mode,
+    contextQuery.data,
+    countryQuery.data,
+    bilateralQuery.data,
+    bbvaQuery.data,
+  ]);
+
+  const gdeltSeries = activeGdeltData.series;
+  const gdeltEvents = activeGdeltData.events;
+  const gdeltInsights = activeGdeltData.insights;
+  const gdeltAggregation = activeGdeltData.aggregation;
+
+  const gdeltLoading =
+    datasets.gdelt && (activeGdeltState.isLoading || activeGdeltState.isFetching);
+  const gdeltError =
+    datasets.gdelt && activeGdeltState.isError
+      ? activeGdeltState.error instanceof Error
+        ? activeGdeltState.error.message
+        : "Unknown error"
+      : null;
+
+  const markets = datasets.poly ? polyQuery.data?.markets ?? [] : [];
+  const polyLoading = datasets.poly && (polyQuery.isLoading || polyQuery.isFetching);
+  const polyError =
+    datasets.poly && polyQuery.isError
+      ? polyQuery.error instanceof Error
+        ? polyQuery.error.message
+        : "Unknown error"
+      : null;
+
+  const twitterIntegrationEnabled = process.env.NEXT_PUBLIC_ENABLE_TWITTER === "1";
+  const comingSoon = !datasets.twitter || !twitterIntegrationEnabled;
+
+  const kpiValues = useMemo(
+    () => {
+      if (!datasets.gdelt) {
+        return {
+          totalEvents: undefined,
+          avgTone: undefined,
+          avgImpact: undefined,
+          topPair: undefined,
+        };
+      }
+
+      const totalEventsFromInsights =
+        typeof gdeltInsights?.total_events === "number" ? gdeltInsights.total_events : undefined;
+      const totalEventsFromSeries = gdeltSeries.reduce(
+        (sum, point) => sum + (point.conflict_events ?? 0),
+        0,
+      );
+      const totalEvents =
+        totalEventsFromInsights ?? (totalEventsFromSeries > 0 ? totalEventsFromSeries : undefined);
+
+      const avgToneFromInsights =
+        gdeltInsights &&
+        typeof gdeltInsights.sentiment_analysis === "object" &&
+        gdeltInsights.sentiment_analysis !== null &&
+        typeof gdeltInsights.sentiment_analysis.avg_tone === "number"
+          ? gdeltInsights.sentiment_analysis.avg_tone
+          : undefined;
+
+      const avgTone = avgToneFromInsights ?? average(gdeltSeries.map((point) => point.avg_sentiment));
+      const avgImpact = average(gdeltSeries.map((point) => point.avg_impact));
+      const topPair = topPairFromInsights(gdeltInsights);
+
+      return { totalEvents, avgTone, avgImpact, topPair };
+    },
+    [datasets.gdelt, gdeltInsights, gdeltSeries],
+  );
+
+  const datasetStatuses = useMemo<DatasetStatusEntry[]>(
+    () => [
+      {
+        id: "gdelt",
+        label: "GDELT",
+        lastFetched: toIsoString(activeGdeltState.dataUpdatedAt),
+        status: !datasets.gdelt
+          ? "red"
+          : gdeltError
+          ? "red"
+          : activeGdeltState.isFetching
+          ? "yellow"
+          : "green",
+        fallback: gdeltAggregation === "monthly" ? "Monthly aggregation fallback" : null,
+        enabled: datasets.gdelt,
+      },
+      {
+        id: "poly",
+        label: "Polymarket",
+        lastFetched: toIsoString(polyQuery.dataUpdatedAt),
+        status: !datasets.poly
+          ? "red"
+          : polyError
+          ? "red"
+          : polyQuery.isFetching
+          ? "yellow"
+          : "green",
+        fallback: null,
+        enabled: datasets.poly,
+      },
+      {
+        id: "twitter",
+        label: "Twitter",
+        lastFetched: undefined,
+        status: !datasets.twitter
+          ? "red"
+          : !twitterIntegrationEnabled
+          ? "yellow"
+          : "green",
+        fallback: !twitterIntegrationEnabled ? "Awaiting integration" : null,
+        enabled: datasets.twitter,
+      },
+    ],
+    [
+      activeGdeltState.dataUpdatedAt,
+      activeGdeltState.isFetching,
+      datasets.gdelt,
+      datasets.poly,
+      datasets.twitter,
+      gdeltAggregation,
+      gdeltError,
+      polyError,
+      polyQuery.dataUpdatedAt,
+      polyQuery.isFetching,
+      twitterIntegrationEnabled,
+    ],
+  );
+
+  const recentQueries = useMemo<RecentQueryEntry[]>(
+    () => {
+      const entries: RecentQueryEntry[] = [];
+      if (keywords.length === 0) {
+        return entries;
+      }
+
+      if (datasets.gdelt) {
+        entries.push({
+          query: keywords.join(", "),
+          timestamp: toIsoString(activeGdeltState.dataUpdatedAt) ?? new Date().toISOString(),
+          dataset: `GDELT (${mode.toUpperCase()})`,
+        });
+      }
+
+      if (datasets.poly) {
+        entries.push({
+          query: keywords.join(" "),
+          timestamp: toIsoString(polyQuery.dataUpdatedAt) ?? new Date().toISOString(),
+          dataset: "Polymarket",
+        });
+      }
+
+      return entries;
+    },
+    [
+      activeGdeltState.dataUpdatedAt,
+      datasets.gdelt,
+      datasets.poly,
+      keywords,
+      mode,
+      polyQuery.dataUpdatedAt,
+    ],
+  );
+
   return (
-    <div className="grid grid-cols-1 gap-5 md:grid-cols-12">
-      <PolymarketPanel />
-      <GdeltPanel />
-      <SearchStatePanel />
-    </div>
+    <main className="space-y-6">
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-8 lg:grid-cols-12">
+        <section className="md:col-span-5 lg:col-span-8">
+          {datasets.gdelt ? (
+            <GdeltChart
+              series={gdeltSeries}
+              aggregation={gdeltAggregation}
+              onDateClick={(iso) => setActiveDate(iso)}
+              isLoading={gdeltLoading}
+              error={gdeltError}
+            />
+          ) : (
+            <DisabledDatasetCard
+              title="GDELT dataset disabled"
+              description="Enable the GDELT dataset from the filters to explore temporal activity."
+            />
+          )}
+        </section>
+
+        <section className="md:col-span-3 lg:col-span-4">
+          {datasets.gdelt ? (
+            <KpiCards
+              totalEvents={kpiValues.totalEvents}
+              avgTone={kpiValues.avgTone}
+              avgImpact={kpiValues.avgImpact}
+              topPair={kpiValues.topPair ?? undefined}
+              isLoading={gdeltLoading}
+              error={gdeltError}
+            />
+          ) : (
+            <DisabledDatasetCard
+              title="KPIs unavailable"
+              description="Turn on the GDELT feed to surface sentiment and impact metrics."
+            />
+          )}
+        </section>
+
+        <section className="md:col-span-5 lg:col-span-8">
+          {datasets.gdelt ? (
+            <GdeltEventsList
+              events={gdeltEvents}
+              activeDate={activeDate ?? undefined}
+              onOpen={(event) =>
+                openPanel("event", {
+                  json: event,
+                  title: typeof event.SOURCEURL === "string" ? event.SOURCEURL : "Event details",
+                  url: typeof event.SOURCEURL === "string" ? event.SOURCEURL : undefined,
+                })
+              }
+              isLoading={gdeltLoading}
+              error={gdeltError}
+            />
+          ) : (
+            <DisabledDatasetCard
+              title="Events hidden"
+              description="Activate the GDELT stream to review the underlying source events."
+            />
+          )}
+        </section>
+
+        <section className="md:col-span-3 lg:col-span-4">
+          {datasets.poly ? (
+            <PolyMarketGrid
+              markets={markets}
+              onOpen={(id) => openPanel("market", { id })}
+              isLoading={polyLoading}
+              error={polyError}
+            />
+          ) : (
+            <DisabledDatasetCard
+              title="Polymarket disabled"
+              description="Enable the Polymarket dataset to browse high-liquidity markets."
+            />
+          )}
+        </section>
+
+        <section className="md:col-span-3 lg:col-span-5">
+          <TwitterPlaceholder comingSoon={comingSoon} />
+        </section>
+
+        <section className="md:col-span-3 lg:col-span-4">
+          {datasets.gdelt ? (
+            <InsightsPanel insights={gdeltInsights} isLoading={gdeltLoading} error={gdeltError} />
+          ) : (
+            <DisabledDatasetCard
+              title="Insights paused"
+              description="Switch the GDELT dataset back on to surface keyword and actor insights."
+            />
+          )}
+        </section>
+
+        <section className="md:col-span-2 lg:col-span-3">
+          <ActivityPanel datasets={datasetStatuses} recentQueries={recentQueries} />
+        </section>
+      </div>
+    </main>
   );
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,17 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
+import AdvancedModal from "@/components/gdelt/AdvancedModal";
 import DatePresets from "@/components/search/DatePresets";
 import DatasetToggles from "@/components/search/DatasetToggles";
 import { CUSTOM_PRESET_EVENT, SEARCH_SUBMIT_EVENT } from "@/components/search/events";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
@@ -46,6 +40,7 @@ export default function SearchBar({
   const toggleDataset = useGlobalFilters((state) => state.toggleDataset);
 
   const [query, setQuery] = useState(() => keywords.join(" "));
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   useEffect(() => {
     const joined = keywords.join(" ");
@@ -141,20 +136,6 @@ export default function SearchBar({
     "md:h-14"
   );
 
-  const dialogContent = useMemo(
-    () => (
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Advanced search</DialogTitle>
-        </DialogHeader>
-        <div className="rounded-3xl border border-dashed border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/70 p-6 text-sm text-[color:var(--muted)]">
-          Controls coming soon.
-        </div>
-      </DialogContent>
-    ),
-    []
-  );
-
   return (
     <div className="mx-auto w-full max-w-[760px]">
       {loading ? (
@@ -212,20 +193,16 @@ export default function SearchBar({
       <div className="mt-2 flex flex-wrap items-center gap-2">
         <DatePresets disabled={loading} />
         <DatasetToggles disabled={loading} />
-        <Dialog>
-          <DialogTrigger asChild>
-            <Button
-              type="button"
-              size="sm"
-              variant="ghost"
-              className="rounded-2xl border border-transparent bg-[color:var(--surface-2)]/80 px-3 text-[13px] text-[color:var(--muted)] transition hover:border-[color:var(--primary)]/35 hover:bg-[color:var(--primary)]/12 hover:text-[color:var(--text)]"
-              disabled={loading}
-            >
-              Advanced
-            </Button>
-          </DialogTrigger>
-          {dialogContent}
-        </Dialog>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="rounded-2xl border border-transparent bg-[color:var(--surface-2)]/80 px-3 text-[13px] text-[color:var(--muted)] transition hover:border-[color:var(--primary)]/35 hover:bg-[color:var(--primary)]/12 hover:text-[color:var(--text)]"
+          disabled={loading}
+          onClick={() => setAdvancedOpen(true)}
+        >
+          Advanced
+        </Button>
       </div>
 
       <div className="pointer-events-none mt-1 h-[2px] rounded-full bg-[radial-gradient(60%_80%_at_50%_50%,rgba(224,36,36,0.45),transparent)]" />
@@ -244,6 +221,7 @@ export default function SearchBar({
           )}
         </div>
       )}
+      <AdvancedModal open={advancedOpen} onOpenChange={setAdvancedOpen} />
     </div>
   );
 }

--- a/src/components/gdelt/AdvancedModal.tsx
+++ b/src/components/gdelt/AdvancedModal.tsx
@@ -1,0 +1,479 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useToast } from "@/components/ui/use-toast";
+import { useGlobalFilters } from "@/stores/useGlobalFilters";
+import {
+  BbvaParams,
+  BilateralParams,
+  ContextParams,
+  CountryParams,
+  GdeltMode,
+  useGdeltMode,
+} from "@/stores/useGdeltMode";
+
+const MAX_RANGE_DAYS = 365;
+
+type AdvancedModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+type CountryOption = {
+  value: string;
+  label: string;
+};
+
+function parseYYYYMMDD(value: string): Date {
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(4, 6));
+  const day = Number(value.slice(6, 8));
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function differenceInDays(start: Date, end: Date): number {
+  const normalizedStart = start.getTime();
+  const normalizedEnd = end.getTime();
+  return Math.floor(Math.abs(normalizedEnd - normalizedStart) / (24 * 60 * 60 * 1000)) + 1;
+}
+
+function formatRange(start: string, end: string) {
+  const toDisplay = (value: string) =>
+    `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
+  return `${toDisplay(start)} → ${toDisplay(end)}`;
+}
+
+export default function AdvancedModal({ open, onOpenChange }: AdvancedModalProps) {
+  const { toast } = useToast();
+  const dateStart = useGlobalFilters((state) => state.dateStart);
+  const dateEnd = useGlobalFilters((state) => state.dateEnd);
+  const keywords = useGlobalFilters((state) => state.keywords);
+
+  const { mode, params, setMode } = useGdeltMode();
+
+  const [hydrated, setHydrated] = useState(false);
+  const [activeTab, setActiveTab] = useState<GdeltMode>(mode);
+  const [contextParams, setContextParams] = useState<ContextParams>(() => ({
+    includeInsights: params.context?.includeInsights ?? true,
+    limit: params.context?.limit ?? 500,
+  }));
+  const [countryParams, setCountryParams] = useState<CountryParams>(() => ({
+    country: params.country?.country ?? "USA",
+  }));
+  const [bilateralParams, setBilateralParams] = useState<BilateralParams>(() => ({
+    country1: params.bilateral?.country1 ?? "USA",
+    country2: params.bilateral?.country2 ?? "CHN",
+  }));
+  const [bbvaParams, setBbvaParams] = useState<BbvaParams>(() => ({
+    actor1: params.bbva?.actor1 ?? "USA",
+    actor2: params.bbva?.actor2 ?? "CHN",
+    includeTotal: params.bbva?.includeTotal ?? false,
+    cameoCodes: params.bbva?.cameoCodes ?? "",
+  }));
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    setActiveTab(mode);
+    setContextParams({
+      includeInsights: params.context?.includeInsights ?? true,
+      limit: params.context?.limit ?? 500,
+    });
+    setCountryParams({ country: params.country?.country ?? "USA" });
+    setBilateralParams({
+      country1: params.bilateral?.country1 ?? "USA",
+      country2: params.bilateral?.country2 ?? "CHN",
+    });
+    setBbvaParams({
+      actor1: params.bbva?.actor1 ?? "USA",
+      actor2: params.bbva?.actor2 ?? "CHN",
+      includeTotal: params.bbva?.includeTotal ?? false,
+      cameoCodes: params.bbva?.cameoCodes ?? "",
+    });
+  }, [mode, open, params.bbva, params.bilateral, params.context, params.country]);
+
+  const countryOptions = useMemo<CountryOption[]>(
+    () => [
+      { value: "USA", label: "United States" },
+      { value: "CHN", label: "China" },
+      { value: "RUS", label: "Russia" },
+      { value: "UKR", label: "Ukraine" },
+      { value: "ISR", label: "Israel" },
+      { value: "IRN", label: "Iran" },
+      { value: "DEU", label: "Germany" },
+      { value: "FRA", label: "France" },
+      { value: "GBR", label: "United Kingdom" },
+      { value: "TUR", label: "Turkey" },
+      { value: "IND", label: "India" },
+      { value: "PAK", label: "Pakistan" },
+      { value: "SAU", label: "Saudi Arabia" },
+      { value: "BRA", label: "Brazil" },
+      { value: "ZAF", label: "South Africa" },
+      { value: "AUS", label: "Australia" },
+      { value: "CAN", label: "Canada" },
+      { value: "JPN", label: "Japan" },
+    ],
+    []
+  );
+
+  const applyContext = () => {
+    const limit = Number.isFinite(Number(contextParams.limit))
+      ? Math.max(1, Math.min(1000, Number(contextParams.limit)))
+      : 500;
+
+    setMode("context", { includeInsights: contextParams.includeInsights, limit });
+    return true;
+  };
+
+  const applyCountry = () => {
+    if (!countryParams.country) {
+      toast({
+        title: "Select a country",
+        description: "Choose a country to run a country-level query.",
+      });
+      return false;
+    }
+
+    setMode("country", { country: countryParams.country });
+    return true;
+  };
+
+  const applyBilateral = () => {
+    if (!bilateralParams.country1 || !bilateralParams.country2) {
+      toast({
+        title: "Missing countries",
+        description: "Select both countries to run a bilateral query.",
+      });
+      return false;
+    }
+
+    if (bilateralParams.country1 === bilateralParams.country2) {
+      toast({
+        title: "Distinct countries required",
+        description: "Choose two different countries for bilateral coverage.",
+      });
+      return false;
+    }
+
+    setMode("bilateral", {
+      country1: bilateralParams.country1,
+      country2: bilateralParams.country2,
+    });
+    return true;
+  };
+
+  const applyBbva = () => {
+    if (!bbvaParams.actor1 || !bbvaParams.actor2) {
+      toast({
+        title: "Missing actors",
+        description: "Select both actors to compare conflict coverage.",
+      });
+      return false;
+    }
+
+    setMode("bbva", {
+      actor1: bbvaParams.actor1,
+      actor2: bbvaParams.actor2,
+      includeTotal: bbvaParams.includeTotal,
+      cameoCodes: bbvaParams.cameoCodes?.trim() || undefined,
+    });
+    return true;
+  };
+
+  const handleApply = () => {
+    const start = parseYYYYMMDD(dateStart);
+    const end = parseYYYYMMDD(dateEnd);
+    const days = differenceInDays(start, end);
+
+    if (days > MAX_RANGE_DAYS) {
+      toast({
+        title: "Range too large",
+        description: "Advanced queries are limited to 365 days.",
+      });
+      return;
+    }
+
+    let applied = true;
+
+    switch (activeTab) {
+      case "context":
+        applied = applyContext();
+        break;
+      case "country":
+        applied = applyCountry();
+        break;
+      case "bilateral":
+        applied = applyBilateral();
+        break;
+      case "bbva":
+        applied = applyBbva();
+        break;
+      default:
+        applied = false;
+        break;
+    }
+
+    if (applied) {
+      toast({
+        title: "Advanced mode applied",
+        description: `Running ${activeTab} mode for ${formatRange(dateStart, dateEnd)}${
+          keywords.length ? ` • ${keywords.join(", ")}` : ""
+        }`,
+      });
+      onOpenChange(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl bg-[color:var(--surface-3)]/95">
+        <DialogHeader className="space-y-2">
+          <DialogTitle>Advanced GDELT modes</DialogTitle>
+          <DialogDescription className="text-[color:var(--muted)]">
+            Tailor the request type for the active date range {formatRange(dateStart, dateEnd)}.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!hydrated ? (
+          <div className="space-y-3">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-12 rounded-2xl bg-gradient-to-r from-[color:var(--surface-2)] to-[color:var(--surface)]/60 animate-pulse"
+              />
+            ))}
+          </div>
+        ) : (
+          <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as GdeltMode)} className="space-y-5">
+            <TabsList className="relative flex w-full flex-wrap justify-start gap-2 rounded-2xl bg-[color:var(--surface-2)]/60 p-1">
+              <TabsTrigger value="context" className="px-4 py-1.5">
+                Context
+              </TabsTrigger>
+              <TabsTrigger value="country" className="px-4 py-1.5">
+                Country
+              </TabsTrigger>
+              <TabsTrigger value="bilateral" className="px-4 py-1.5">
+                Bilateral
+              </TabsTrigger>
+              <TabsTrigger value="bbva" className="px-4 py-1.5">
+                BBVA
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="context" className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="rounded-2xl border border-[color:var(--border)]/50 bg-[color:var(--surface-2)]/60 p-4">
+                  <h3 className="text-sm font-semibold text-[color:var(--text)]">Insights</h3>
+                  <p className="mt-1 text-xs text-[color:var(--muted)]">
+                    Include aggregated insights alongside the event series response.
+                  </p>
+                  <label className="mt-3 flex items-center gap-3 text-sm text-[color:var(--text)]">
+                    <Checkbox
+                      checked={contextParams.includeInsights}
+                      onCheckedChange={(checked) =>
+                        setContextParams((prev) => ({
+                          ...prev,
+                          includeInsights: Boolean(checked),
+                        }))
+                      }
+                    />
+                    Include insights panel data
+                  </label>
+                </div>
+                <div className="rounded-2xl border border-[color:var(--border)]/50 bg-[color:var(--surface-2)]/60 p-4">
+                  <h3 className="text-sm font-semibold text-[color:var(--text)]">Result window</h3>
+                  <p className="mt-1 text-xs text-[color:var(--muted)]">
+                    Limit the maximum number of timeline rows returned from the proxy.
+                  </p>
+                  <div className="mt-3">
+                    <label className="text-xs uppercase tracking-wide text-[color:var(--muted)]">
+                      Limit
+                    </label>
+                    <input
+                      type="number"
+                      min={1}
+                      max={1000}
+                      value={contextParams.limit}
+                      onChange={(event) =>
+                        setContextParams((prev) => ({
+                          ...prev,
+                          limit: Number(event.target.value),
+                        }))
+                      }
+                      className="mt-1 w-full rounded-2xl border border-[color:var(--border)]/60 bg-[color:var(--surface)]/70 px-3 py-2 text-sm text-[color:var(--text)] focus:outline-none focus:ring-2 focus:ring-[color:var(--primary)]/45"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div className="rounded-2xl border border-dashed border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/40 p-4 text-xs text-[color:var(--muted)]">
+                Keywords in play: {keywords.length ? keywords.join(", ") : "None"}
+              </div>
+            </TabsContent>
+
+            <TabsContent value="country" className="space-y-4">
+              <div className="rounded-2xl border border-[color:var(--border)]/50 bg-[color:var(--surface-2)]/60 p-4">
+                <label className="text-xs uppercase tracking-wide text-[color:var(--muted)]">
+                  Country
+                </label>
+                <Select
+                  value={countryParams.country}
+                  onValueChange={(value) => setCountryParams({ country: value })}
+                >
+                  <SelectTrigger className="mt-2" aria-label="Select country">
+                    <SelectValue placeholder="Select a country" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {countryOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </TabsContent>
+
+            <TabsContent value="bilateral" className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                {["country1", "country2"].map((field, index) => (
+                  <div
+                    key={field}
+                    className="rounded-2xl border border-[color:var(--border)]/50 bg-[color:var(--surface-2)]/60 p-4"
+                  >
+                    <label className="text-xs uppercase tracking-wide text-[color:var(--muted)]">
+                      {index === 0 ? "Primary country" : "Counterparty"}
+                    </label>
+                    <Select
+                      value={(bilateralParams as Record<string, string>)[field]}
+                      onValueChange={(value) =>
+                        setBilateralParams((prev) => ({
+                          ...prev,
+                          [field]: value,
+                        }))
+                      }
+                    >
+                      <SelectTrigger className="mt-2" aria-label={index === 0 ? "Primary country" : "Counterparty"}>
+                        <SelectValue placeholder="Select a country" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {countryOptions.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                ))}
+              </div>
+              <p className="text-xs text-[color:var(--muted)]">
+                Compare bilateral coverage between two actors. Daily timeline is returned when available.
+              </p>
+            </TabsContent>
+
+            <TabsContent value="bbva" className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                {["actor1", "actor2"].map((field, index) => (
+                  <div
+                    key={field}
+                    className="rounded-2xl border border-[color:var(--border)]/50 bg-[color:var(--surface-2)]/60 p-4"
+                  >
+                    <label className="text-xs uppercase tracking-wide text-[color:var(--muted)]">
+                      {index === 0 ? "Actor 1" : "Actor 2"}
+                    </label>
+                    <Select
+                      value={(bbvaParams as Record<string, string | boolean>)[field] as string}
+                      onValueChange={(value) =>
+                        setBbvaParams((prev) => ({
+                          ...prev,
+                          [field]: value,
+                        }))
+                      }
+                    >
+                      <SelectTrigger className="mt-2" aria-label={index === 0 ? "Actor 1" : "Actor 2"}>
+                        <SelectValue placeholder="Select an actor" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {countryOptions.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                ))}
+              </div>
+              <div className="rounded-2xl border border-[color:var(--border)]/50 bg-[color:var(--surface-2)]/60 p-4">
+                <label className="flex items-center gap-3 text-sm text-[color:var(--text)]">
+                  <Checkbox
+                    checked={bbvaParams.includeTotal}
+                    onCheckedChange={(checked) =>
+                      setBbvaParams((prev) => ({
+                        ...prev,
+                        includeTotal: Boolean(checked),
+                      }))
+                    }
+                  />
+                  Include total conflict coverage
+                </label>
+                <div className="mt-4">
+                  <label className="text-xs uppercase tracking-wide text-[color:var(--muted)]">
+                    CAMEO codes (optional)
+                  </label>
+                  <input
+                    type="text"
+                    placeholder="e.g. 141,142"
+                    value={bbvaParams.cameoCodes}
+                    onChange={(event) =>
+                      setBbvaParams((prev) => ({
+                        ...prev,
+                        cameoCodes: event.target.value,
+                      }))
+                    }
+                    className="mt-1 w-full rounded-2xl border border-[color:var(--border)]/60 bg-[color:var(--surface)]/70 px-3 py-2 text-sm text-[color:var(--text)] focus:outline-none focus:ring-2 focus:ring-[color:var(--primary)]/45"
+                  />
+                </div>
+              </div>
+              <p className="text-xs text-[color:var(--muted)]">
+                Use BBVA conflict coverage mode for specialized bilateral analysis filters.
+              </p>
+            </TabsContent>
+          </Tabs>
+        )}
+
+        <DialogFooter className="mt-4">
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleApply}>Apply mode</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/gdelt/GdeltChart.tsx
+++ b/src/components/gdelt/GdeltChart.tsx
@@ -1,0 +1,199 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import {
+  Area,
+  AreaChart,
+  Brush,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import type { GdeltSeriesPoint } from "@/types"
+
+interface GdeltChartProps {
+  series: GdeltSeriesPoint[]
+  aggregation?: "daily" | "monthly"
+  onDateClick?: (iso: string) => void
+  isLoading?: boolean
+  error?: string | null
+}
+
+const METRIC_CONFIG = {
+  conflict_events: {
+    label: "Events",
+    color: "#f87171",
+    chart: "line" as const,
+  },
+  avg_sentiment: {
+    label: "Sentiment",
+    color: "#f43f5e",
+    chart: "area" as const,
+  },
+  avg_impact: {
+    label: "Impact",
+    color: "#ef4444",
+    chart: "line" as const,
+  },
+  relative_coverage: {
+    label: "Rel Coverage",
+    color: "#dc2626",
+    chart: "line" as const,
+  },
+}
+
+type MetricKey = keyof typeof METRIC_CONFIG
+
+const tooltipFormatter = (value?: number | string) => {
+  if (value === null || value === undefined || value === "") {
+    return "–"
+  }
+  if (typeof value === "number") {
+    if (Math.abs(value) >= 1000) {
+      return value.toLocaleString(undefined, { maximumFractionDigits: 0 })
+    }
+    return value.toLocaleString(undefined, { maximumFractionDigits: 2 })
+  }
+  return value
+}
+
+export function GdeltChart({
+  series,
+  aggregation = "daily",
+  onDateClick,
+  isLoading = false,
+  error,
+}: GdeltChartProps) {
+  const [metric, setMetric] = useState<MetricKey>("conflict_events")
+
+  const preparedSeries = useMemo(() => {
+    return series.map((point) => ({
+      ...point,
+      conflict_events: point.conflict_events ?? 0,
+      avg_sentiment: point.avg_sentiment ?? 0,
+      avg_impact: point.avg_impact ?? 0,
+      relative_coverage: point.relative_coverage ?? 0,
+    }))
+  }, [series])
+
+  const selectedMetric = METRIC_CONFIG[metric]
+  const hasData = preparedSeries.length > 0
+
+  if (isLoading) {
+    return (
+      <div className="relative h-[380px] overflow-hidden rounded-3xl bg-gradient-to-br from-[var(--surface)] to-[var(--surface-2)] p-4">
+        {aggregation === "monthly" && (
+          <span className="absolute right-4 top-3 rounded-full bg-[var(--primary)]/20 px-2 py-1 text-xs font-medium text-[var(--primary)]">
+            Monthly aggregation
+          </span>
+        )}
+        <div className="flex h-full w-full flex-col gap-4">
+          <div className="h-8 w-48 animate-pulse rounded-full bg-gradient-to-r from-[var(--surface-2)] to-[var(--surface-3)]" />
+          <div className="flex-1 animate-pulse rounded-3xl bg-gradient-to-br from-[var(--surface-2)] via-[var(--surface-3)] to-[var(--surface-2)]" />
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="relative h-[380px] rounded-3xl border border-red-400/40 bg-red-500/10 p-4 text-red-200">
+        <p className="text-sm font-medium">Unable to load GDELT data</p>
+        <p className="mt-2 text-xs opacity-80">{error}</p>
+      </div>
+    )
+  }
+
+  if (!hasData) {
+    return (
+      <div className="relative flex h-[380px] flex-col items-center justify-center rounded-3xl bg-gradient-to-br from-[var(--surface)] to-[var(--surface-2)] p-4 text-sm text-muted-foreground">
+        <p>No activity found for the selected filters.</p>
+      </div>
+    )
+  }
+
+  const ChartComponent = selectedMetric.chart === "area" ? AreaChart : LineChart
+
+  return (
+    <div className="relative h-[380px] rounded-3xl bg-gradient-to-br from-[var(--surface)] to-[var(--surface-2)] p-4 shadow-lg shadow-black/5">
+      {aggregation === "monthly" && (
+        <span className="absolute right-4 top-3 rounded-full bg-[var(--primary)]/20 px-2 py-1 text-xs font-medium text-[var(--primary)]">
+          Monthly aggregation
+        </span>
+      )}
+      <Tabs
+        value={metric}
+        onValueChange={(value) => setMetric(value as MetricKey)}
+        className="flex h-full flex-col"
+      >
+        <TabsList className="w-max bg-[var(--surface-2)]/70 backdrop-blur">
+          {(Object.entries(METRIC_CONFIG) as [MetricKey, (typeof METRIC_CONFIG)[MetricKey]][]).map(([key, config]) => (
+            <TabsTrigger key={key} value={key} className="min-w-[96px]">
+              {config.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        <TabsContent value={metric} className="mt-6 flex-1">
+          <ResponsiveContainer width="100%" height="100%">
+            <ChartComponent
+              data={preparedSeries}
+              margin={{ top: 16, right: 24, left: 0, bottom: 16 }}
+              onClick={(state) => {
+                const payload = state?.activePayload?.[0]?.payload as GdeltSeriesPoint | undefined
+                if (payload?.date && onDateClick) {
+                  onDateClick(payload.date)
+                }
+              }}
+            >
+              <defs>
+                <linearGradient id="gdeltSentimentGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={selectedMetric.color} stopOpacity={0.4} />
+                  <stop offset="95%" stopColor={selectedMetric.color} stopOpacity={0.05} />
+                </linearGradient>
+              </defs>
+              <XAxis dataKey="date" tick={{ fill: "var(--muted-foreground)" }} tickLine={false} axisLine={false} minTickGap={24} />
+              <YAxis
+                tick={{ fill: "var(--muted-foreground)" }}
+                tickLine={false}
+                axisLine={false}
+                width={60}
+                tickFormatter={(value) => tooltipFormatter(value as number) as string}
+              />
+              <Tooltip
+                wrapperClassName="!bg-transparent"
+                contentStyle={{ borderRadius: 16, border: "none", boxShadow: "0 10px 30px rgba(0,0,0,0.25)", background: "var(--surface)" }}
+                labelStyle={{ fontWeight: 600, color: "var(--foreground)" }}
+                formatter={(value) => [tooltipFormatter(value) as string, selectedMetric.label]}
+              />
+              <Brush dataKey="date" height={24} stroke={selectedMetric.color} travellerWidth={12} />
+              {selectedMetric.chart === "area" ? (
+                <Area
+                  type="monotone"
+                  dataKey={metric}
+                  stroke={selectedMetric.color}
+                  fill="url(#gdeltSentimentGradient)"
+                  strokeWidth={3}
+                  dot={false}
+                />
+              ) : (
+                <Line
+                  type="monotone"
+                  dataKey={metric}
+                  stroke={selectedMetric.color}
+                  strokeWidth={3}
+                  dot={{ r: 2, strokeWidth: 1, stroke: selectedMetric.color, fill: "var(--surface)" }}
+                  activeDot={{ r: 4 }}
+                />
+              )}
+            </ChartComponent>
+          </ResponsiveContainer>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/src/components/gdelt/GdeltEventsList.tsx
+++ b/src/components/gdelt/GdeltEventsList.tsx
@@ -45,7 +45,7 @@ function getHostnameAndPath(url?: string) {
     const hostname = parsed.hostname.replace(/^www\./i, "");
     const path = parsed.pathname === "/" && !parsed.search ? "" : `${parsed.pathname}${parsed.search}`;
     return { hostname, path };
-  } catch (error) {
+  } catch {
     return { hostname: url, path: "" };
   }
 }
@@ -87,8 +87,8 @@ export function GdeltEventsList({
       const tone = typeof event.AvgTone === "number" ? event.AvgTone : undefined;
       const countryCodes = [
         typeof event.Actor1CountryCode === "string" ? event.Actor1CountryCode : undefined,
-        typeof (event as any).Actor2CountryCode === "string" ? (event as any).Actor2CountryCode : undefined,
-      ].filter(Boolean) as string[];
+        typeof event.Actor2CountryCode === "string" ? event.Actor2CountryCode : undefined,
+      ].filter((code): code is string => Boolean(code));
 
       return {
         original: event,

--- a/src/components/gdelt/GdeltEventsList.tsx
+++ b/src/components/gdelt/GdeltEventsList.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useMemo, useRef } from "react";
+import Link from "next/link";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import clsx from "clsx";
+import { ExternalLink, Flag } from "lucide-react";
+
+import type { GdeltEvent } from "@/types";
+import { normalizeGdeltDate } from "@/hooks/utils";
+
+interface GdeltEventsListProps {
+  events: GdeltEvent[];
+  activeDate?: string;
+  onOpen?: (event: GdeltEvent) => void;
+  isLoading?: boolean;
+  error?: string | null;
+}
+
+interface NormalizedEvent {
+  original: GdeltEvent;
+  id: string;
+  isoDate: string;
+  hostname: string;
+  path: string;
+  tone?: number;
+  eventCode?: string;
+  countryCodes: string[];
+}
+
+function truncate(value: string, max = 48) {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max - 1)}…`;
+}
+
+function getHostnameAndPath(url?: string) {
+  if (!url) {
+    return { hostname: "", path: "" };
+  }
+
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.replace(/^www\./i, "");
+    const path = parsed.pathname === "/" && !parsed.search ? "" : `${parsed.pathname}${parsed.search}`;
+    return { hostname, path };
+  } catch (error) {
+    return { hostname: url, path: "" };
+  }
+}
+
+function isNegativeEvent(code?: string, tone?: number) {
+  if (!code) {
+    return tone != null && tone < 0;
+  }
+
+  const numeric = Number.parseInt(code, 10);
+  if (Number.isNaN(numeric)) {
+    return tone != null && tone < 0;
+  }
+
+  return numeric >= 180 || (tone != null && tone < 0);
+}
+
+function toneLabel(tone?: number) {
+  if (tone == null) {
+    return "–";
+  }
+
+  return tone.toFixed(1);
+}
+
+export function GdeltEventsList({
+  events,
+  activeDate,
+  onOpen,
+  isLoading = false,
+  error,
+}: GdeltEventsListProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const normalizedEvents = useMemo<NormalizedEvent[]>(() => {
+    return events.slice(0, 500).map((event, index) => {
+      const isoDate = normalizeGdeltDate(event.SQLDATE);
+      const { hostname, path } = getHostnameAndPath(String(event.SOURCEURL ?? ""));
+      const tone = typeof event.AvgTone === "number" ? event.AvgTone : undefined;
+      const countryCodes = [
+        typeof event.Actor1CountryCode === "string" ? event.Actor1CountryCode : undefined,
+        typeof (event as any).Actor2CountryCode === "string" ? (event as any).Actor2CountryCode : undefined,
+      ].filter(Boolean) as string[];
+
+      return {
+        original: event,
+        id: `${isoDate}-${hostname}-${path}-${index}`,
+        isoDate,
+        hostname,
+        path,
+        tone,
+        eventCode: typeof event.EventCode === "string" ? event.EventCode : undefined,
+        countryCodes,
+      };
+    });
+  }, [events]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: normalizedEvents.length,
+    getScrollElement: () => containerRef.current,
+    estimateSize: () => 88,
+    overscan: 12,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="relative h-[400px] rounded-3xl bg-gradient-to-br from-[color:var(--surface)] to-[color:var(--surface-2)] p-4">
+        <div className="flex flex-col gap-4">
+          <div className="h-6 w-40 animate-pulse rounded-full bg-gradient-to-r from-[color:var(--surface-2)] to-[color:var(--surface-3)]" />
+          <div className="space-y-3">
+            {Array.from({ length: 6 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-16 animate-pulse rounded-2xl bg-gradient-to-r from-[color:var(--surface-2)] via-[color:var(--surface-3)] to-[color:var(--surface-2)]"
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="relative h-[400px] rounded-3xl border border-red-400/40 bg-red-500/10 p-4 text-red-200">
+        <p className="text-sm font-medium">Unable to load GDELT events</p>
+        <p className="mt-2 text-xs opacity-80">{error}</p>
+      </div>
+    );
+  }
+
+  if (normalizedEvents.length === 0) {
+    return (
+      <div className="relative flex h-[400px] flex-col items-center justify-center rounded-3xl bg-gradient-to-br from-[color:var(--surface)] to-[color:var(--surface-2)] p-4 text-sm text-[color:var(--muted)]">
+        <p>No GDELT events found for the selected period.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-[400px] overflow-hidden rounded-3xl bg-gradient-to-br from-[color:var(--surface)] to-[color:var(--surface-2)] p-4 shadow-lg shadow-black/5">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-[color:var(--text)]">Event stream</h3>
+          <p className="text-xs text-[color:var(--muted)]">Live slice of the latest {normalizedEvents.length.toLocaleString()} articles.</p>
+        </div>
+      </div>
+
+      <div
+        ref={containerRef}
+        className="mt-4 h-[320px] overflow-y-auto pr-2"
+      >
+        <div
+          style={{
+            height: `${rowVirtualizer.getTotalSize()}px`,
+            position: "relative",
+          }}
+        >
+          {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+            const event = normalizedEvents[virtualRow.index];
+            const isActive = activeDate && event.isoDate === activeDate;
+            const negative = isNegativeEvent(event.eventCode, event.tone);
+
+            return (
+              <div
+                key={event.id}
+                data-index={virtualRow.index}
+                className="absolute left-0 right-0 px-1"
+                style={{
+                  transform: `translateY(${virtualRow.start}px)`,
+                  height: `${virtualRow.size}px`,
+                }}
+              >
+                <div
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => onOpen?.(event.original)}
+                  onKeyDown={(keyboardEvent) => {
+                    if (keyboardEvent.key === "Enter" || keyboardEvent.key === " ") {
+                      keyboardEvent.preventDefault();
+                      onOpen?.(event.original);
+                    }
+                  }}
+                  className={clsx(
+                    "group flex h-full cursor-pointer flex-col justify-center rounded-2xl border border-transparent bg-[color:var(--surface-2)]/40 px-4 py-3 shadow-sm shadow-black/5 transition",
+                    isActive && "border-[color:var(--primary)]/60 bg-[color:var(--primary)]/10",
+                    !isActive && "hover:border-[color:var(--primary)]/40 hover:bg-[color:var(--surface-2)]/70",
+                  )}
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-semibold text-[color:var(--text)]">
+                        {event.hostname || "Unknown source"}
+                      </p>
+                      {event.path && (
+                        <p className="truncate text-xs text-[color:var(--muted)]">{truncate(event.path)}</p>
+                      )}
+                      {event.isoDate && (
+                        <p className="mt-1 text-xs uppercase tracking-wide text-[color:var(--muted)]">{event.isoDate}</p>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      {event.eventCode && (
+                        <span
+                          className={clsx(
+                            "rounded-full border px-2 py-0.5 text-xs font-medium",
+                            negative
+                              ? "border-red-500/40 bg-red-500/15 text-red-200"
+                              : "border-[color:var(--primary)]/40 bg-[color:var(--primary)]/15 text-[color:var(--primary)]",
+                          )}
+                        >
+                          Code {event.eventCode}
+                        </span>
+                      )}
+                      {event.tone != null && (
+                        <span
+                          className={clsx(
+                            "rounded-full border px-2 py-0.5 text-xs font-semibold",
+                            event.tone > 1
+                              ? "border-emerald-400/40 bg-emerald-500/15 text-emerald-200"
+                              : event.tone < -1
+                              ? "border-red-500/40 bg-red-500/15 text-red-200"
+                              : "border-[color:var(--border)]/60 bg-[color:var(--surface-3)]/40 text-[color:var(--text)]",
+                          )}
+                        >
+                          Tone {toneLabel(event.tone)}
+                        </span>
+                      )}
+                      {event.countryCodes.length > 0 && (
+                        <span className="flex items-center gap-2">
+                          {event.countryCodes.map((code) => (
+                            <span
+                              key={`${event.id}-${code}`}
+                              className="flex items-center gap-1 rounded-full border border-[color:var(--border)]/60 bg-[color:var(--surface-3)]/40 px-2 py-0.5 text-xs text-[color:var(--text)]"
+                            >
+                              <Flag className="h-3 w-3 opacity-60" aria-hidden="true" />
+                              {code}
+                            </span>
+                          ))}
+                        </span>
+                      )}
+                      {event.original.SOURCEURL && (
+                        <Link
+                          href={event.original.SOURCEURL}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-white/10 bg-white/5 text-[color:var(--text)] transition hover:border-[color:var(--primary)]/50 hover:bg-[color:var(--primary)]/20"
+                          onClick={(clickEvent) => clickEvent.stopPropagation()}
+                        >
+                          <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                          <span className="sr-only">Open source</span>
+                        </Link>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default GdeltEventsList;

--- a/src/components/gdelt/InsightsPanel.tsx
+++ b/src/components/gdelt/InsightsPanel.tsx
@@ -1,0 +1,249 @@
+"use client"
+
+import { useMemo } from "react"
+import {
+  Bar,
+  BarChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+
+import type { GdeltInsights } from "@/types"
+
+interface InsightsPanelProps {
+  insights?: GdeltInsights | null
+  isLoading?: boolean
+  error?: string | null
+}
+
+interface KeywordEntry {
+  keyword: string
+  count: number
+}
+
+interface TemporalEntry {
+  label: string
+  value: number
+}
+
+interface ActorEntry {
+  name: string
+  count?: number
+}
+
+const toKeywordEntries = (matches?: Record<string, number>): KeywordEntry[] => {
+  if (!matches) return []
+
+  return Object.entries(matches)
+    .map(([keyword, count]) => ({ keyword, count }))
+    .filter((entry) => Number.isFinite(entry.count))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5)
+}
+
+const toTemporalEntries = (insights?: GdeltInsights): TemporalEntry[] => {
+  const raw = (insights?.temporal_distribution ?? insights?.timeline ?? []) as unknown[]
+
+  return raw
+    .map((item) => {
+      if (typeof item === "object" && item !== null) {
+        const record = item as Record<string, unknown>
+        const label = typeof record.date === "string" ? record.date : typeof record.label === "string" ? record.label : null
+        const valueCandidate = record.count ?? record.value ?? record.total
+        const value = typeof valueCandidate === "number" ? valueCandidate : Number(valueCandidate)
+        if (label && Number.isFinite(value)) {
+          return { label, value }
+        }
+      }
+      return null
+    })
+    .filter((entry): entry is TemporalEntry => Boolean(entry))
+}
+
+const toActorEntries = (insights?: GdeltInsights): ActorEntry[] => {
+  const { top_actors, actor_counts } = (insights ?? {}) as Record<string, unknown>
+
+  const raw = Array.isArray(top_actors)
+    ? top_actors
+    : Array.isArray(actor_counts)
+      ? actor_counts
+      : typeof top_actors === "object" && top_actors !== null
+        ? Object.entries(top_actors as Record<string, number>).map(([name, count]) => ({ name, count }))
+        : typeof actor_counts === "object" && actor_counts !== null
+          ? Object.entries(actor_counts as Record<string, number>).map(([name, count]) => ({ name, count }))
+          : []
+
+  return (raw as unknown[])
+    .map((item) => {
+      if (typeof item === "string") {
+        return { name: item }
+      }
+      if (typeof item === "object" && item !== null) {
+        const record = item as Record<string, unknown>
+        const name =
+          typeof record.name === "string"
+            ? record.name
+            : typeof record.actor === "string"
+              ? record.actor
+              : typeof record.label === "string"
+                ? record.label
+                : null
+        const countCandidate = record.count ?? record.value ?? record.total
+        const count = typeof countCandidate === "number" ? countCandidate : Number(countCandidate)
+        if (name) {
+          return { name, count: Number.isFinite(count) ? count : undefined }
+        }
+      }
+      return null
+    })
+    .filter((entry): entry is ActorEntry => Boolean(entry))
+    .slice(0, 6)
+}
+
+const toSpikeLabels = (insights?: GdeltInsights): string[] => {
+  const raw = (insights?.spikes ?? []) as unknown[]
+  return raw
+    .map((item) => {
+      if (typeof item === "string") return item
+      if (typeof item === "object" && item !== null) {
+        const record = item as Record<string, unknown>
+        if (typeof record.label === "string") return record.label
+        if (typeof record.date === "string") return record.date
+      }
+      return null
+    })
+    .filter((label): label is string => Boolean(label))
+    .slice(0, 3)
+}
+
+export function InsightsPanel({ insights, isLoading = false, error }: InsightsPanelProps) {
+  const keywords = useMemo(() => toKeywordEntries(insights?.keyword_matches), [insights?.keyword_matches])
+  const temporal = useMemo(() => toTemporalEntries(insights ?? undefined), [insights])
+  const actors = useMemo(() => toActorEntries(insights ?? undefined), [insights])
+  const spikes = useMemo(() => toSpikeLabels(insights ?? undefined), [insights])
+
+  if (error) {
+    return (
+      <div className="card compact rounded-2xl border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-100">
+        {error}
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="card compact space-y-4 rounded-2xl bg-gradient-to-br from-[color:var(--surface-2)] via-[color:var(--surface-3)] to-[color:var(--surface-2)] p-4">
+        <div className="h-5 w-40 animate-pulse rounded-full bg-white/10" />
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <div key={index} className="h-4 w-full animate-pulse rounded-full bg-white/10" />
+          ))}
+        </div>
+        <div className="h-36 animate-pulse rounded-2xl bg-white/10" />
+      </div>
+    )
+  }
+
+  const isEmpty = keywords.length === 0 && temporal.length === 0 && actors.length === 0 && spikes.length === 0
+
+  if (isEmpty) {
+    return (
+      <div className="card compact rounded-2xl border border-dashed border-[color:var(--border)]/70 bg-[color:var(--surface-2)]/50 p-4 text-sm text-[color:var(--muted)]">
+        No insights available yet. Adjust filters or try a different timeframe.
+      </div>
+    )
+  }
+
+  return (
+    <div className="card compact space-y-6 rounded-2xl border border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/60 p-4 shadow-sm shadow-black/5">
+      <header>
+        <h3 className="text-base font-semibold text-[color:var(--text)]">Insights snapshot</h3>
+        <p className="text-xs text-[color:var(--muted)]">Top signals from the current GDELT aggregation.</p>
+      </header>
+
+      {keywords.length > 0 && (
+        <section>
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-[color:var(--muted)]">Top keywords</h4>
+          <ul className="mt-3 space-y-2">
+            {keywords.map((entry) => (
+              <li key={entry.keyword} className="flex items-center justify-between rounded-xl bg-[color:var(--surface-3)]/40 px-3 py-2 text-sm">
+                <span className="font-medium text-[color:var(--text)]">{entry.keyword}</span>
+                <span className="rounded-full bg-[color:var(--primary)]/15 px-2 py-0.5 text-xs font-semibold text-[color:var(--primary)]">
+                  {entry.count.toLocaleString()}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {temporal.length > 0 && (
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-[color:var(--muted)]">Temporal distribution</h4>
+            {spikes.length > 0 && (
+              <div className="flex items-center gap-2 text-xs">
+                {spikes.map((label) => (
+                  <span key={label} className="rounded-full bg-red-500/15 px-2 py-0.5 font-semibold text-red-300">
+                    ⚠️ {label}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="h-40 rounded-2xl bg-[color:var(--surface-3)]/30 p-3">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={temporal} margin={{ top: 8, left: 0, right: 0, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="insightsBar" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#f87171" stopOpacity={0.9} />
+                    <stop offset="95%" stopColor="#f87171" stopOpacity={0.2} />
+                  </linearGradient>
+                </defs>
+                <XAxis dataKey="label" tick={{ fill: "var(--muted-foreground)", fontSize: 11 }} tickLine={false} axisLine={false} hide={temporal.length > 8} />
+                <YAxis tick={{ fill: "var(--muted-foreground)", fontSize: 11 }} tickLine={false} axisLine={false} width={42} />
+                <Tooltip
+                  cursor={{ fill: "rgba(248,113,113,0.1)" }}
+                  contentStyle={{
+                    borderRadius: 12,
+                    border: "none",
+                    background: "var(--surface)",
+                    boxShadow: "0 12px 30px rgba(0,0,0,0.25)",
+                  }}
+                  formatter={(value: number) => [value.toLocaleString(), "Mentions"]}
+                  labelStyle={{ fontWeight: 600 }}
+                />
+                <Bar dataKey="value" fill="url(#insightsBar)" radius={[12, 12, 4, 4]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </section>
+      )}
+
+      {actors.length > 0 && (
+        <section>
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-[color:var(--muted)]">Top actors</h4>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {actors.map((actor) => (
+              <span
+                key={actor.name}
+                className="inline-flex items-center gap-2 rounded-full border border-[color:var(--primary)]/40 bg-[color:var(--surface-3)]/40 px-3 py-1 text-xs font-medium text-[color:var(--text)]"
+              >
+                {actor.name}
+                {typeof actor.count === "number" && (
+                  <span className="rounded-full bg-[color:var(--primary)]/20 px-2 py-0.5 text-[color:var(--primary)]">
+                    {actor.count.toLocaleString()}
+                  </span>
+                )}
+              </span>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}
+
+export default InsightsPanel

--- a/src/components/gdelt/KpiCards.tsx
+++ b/src/components/gdelt/KpiCards.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import clsx from "clsx"
+import { ArrowDownRight, ArrowUpRight } from "lucide-react"
+import { ReactNode, useMemo } from "react"
+
+interface KpiCardsProps {
+  totalEvents?: number
+  avgTone?: number
+  avgImpact?: number
+  topPair?: string
+  isLoading?: boolean
+  error?: string | null
+}
+
+interface KpiCardProps {
+  label: string
+  value: ReactNode
+  trend?: number | null
+}
+
+const formatNumber = (value?: number, options?: Intl.NumberFormatOptions) => {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return "—"
+  }
+  return value.toLocaleString(undefined, options)
+}
+
+const TrendIndicator = ({ value }: { value: number }) => {
+  if (!value) return null
+
+  const isPositive = value > 0
+  const Icon = isPositive ? ArrowUpRight : ArrowDownRight
+
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+        isPositive ? "bg-emerald-500/10 text-emerald-400" : "bg-red-500/10 text-red-400"
+      )}
+    >
+      <Icon className="h-3.5 w-3.5" strokeWidth={2} />
+      {formatNumber(Math.abs(value), {
+        maximumFractionDigits: 1,
+        minimumFractionDigits: 0,
+      })}
+    </span>
+  )
+}
+
+const KpiCard = ({ label, value, trend }: KpiCardProps) => {
+  return (
+    <div className="card compact relative overflow-hidden rounded-2xl border border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/50 p-4 shadow-sm shadow-black/5">
+      <h3 className="text-sm font-medium text-[color:var(--muted)]">{label}</h3>
+      <div className="mt-2 flex items-baseline gap-3">
+        <p className="text-2xl font-semibold tracking-tight text-[color:var(--text)] tabular-nums">{value}</p>
+        {typeof trend === "number" && trend !== 0 ? <TrendIndicator value={trend} /> : null}
+      </div>
+    </div>
+  )
+}
+
+export function KpiCards({
+  totalEvents,
+  avgTone,
+  avgImpact,
+  topPair,
+  isLoading = false,
+  error,
+}: KpiCardsProps) {
+  const items = useMemo(
+    () => [
+      {
+        label: "Total Events",
+        value: formatNumber(totalEvents, { maximumFractionDigits: 0 }),
+      },
+      {
+        label: "Avg Tone",
+        value: formatNumber(avgTone, { maximumFractionDigits: 2, minimumFractionDigits: 2 }),
+        trend: avgTone ?? null,
+      },
+      {
+        label: "Avg Impact",
+        value: formatNumber(avgImpact, { maximumFractionDigits: 2, minimumFractionDigits: 2 }),
+        trend: avgImpact ?? null,
+      },
+      {
+        label: "Top Actor Pair",
+        value: topPair ?? "—",
+      },
+    ],
+    [avgImpact, avgTone, topPair, totalEvents]
+  )
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-100">
+        {error}
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={index}
+            className="card compact h-24 animate-pulse rounded-2xl bg-gradient-to-br from-[color:var(--surface-2)] via-[color:var(--surface-3)] to-[color:var(--surface-2)]"
+          />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      {items.map((item) => (
+        <KpiCard key={item.label} label={item.label} value={item.value} trend={item.trend ?? undefined} />
+      ))}
+    </div>
+  )
+}

--- a/src/components/poly/PolyMarketGrid.tsx
+++ b/src/components/poly/PolyMarketGrid.tsx
@@ -1,0 +1,182 @@
+"use client"
+
+import Link from "next/link"
+import clsx from "clsx"
+
+import type { PolyMarket } from "@/types"
+
+interface PolyMarketGridProps {
+  markets: PolyMarket[]
+  onOpen?: (id: string) => void
+  isLoading?: boolean
+  error?: string | null
+}
+
+const formatNumber = (value?: number) => {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return "—"
+  }
+
+  if (Math.abs(value) >= 1_000_000) {
+    return `${(value / 1_000_000).toLocaleString(undefined, {
+      maximumFractionDigits: 1,
+    })}M`
+  }
+
+  if (Math.abs(value) >= 1_000) {
+    return `${(value / 1_000).toLocaleString(undefined, {
+      maximumFractionDigits: 1,
+    })}K`
+  }
+
+  return value.toLocaleString(undefined, { maximumFractionDigits: 2 })
+}
+
+const formatPrice = (value?: number) => {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return "—"
+  }
+
+  return value.toLocaleString(undefined, {
+    style: "percent",
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  })
+}
+
+const formatDate = (value: string | null) => {
+  if (!value) {
+    return "—"
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })
+}
+
+const statusStyles: Record<string, string> = {
+  active: "bg-emerald-500/10 text-emerald-400 border border-emerald-500/30",
+  trading: "bg-emerald-500/10 text-emerald-400 border border-emerald-500/30",
+  expired: "bg-[color:var(--muted)]/10 text-[color:var(--muted)] border border-[color:var(--muted)]/30",
+  resolved: "bg-blue-500/10 text-blue-300 border border-blue-500/30",
+}
+
+const getStatusClass = (status: string) => {
+  const normalized = status.toLowerCase()
+  return statusStyles[normalized] ?? "bg-[color:var(--surface-3)] text-[color:var(--muted)] border border-[color:var(--border)]/50"
+}
+
+export function PolyMarketGrid({
+  markets,
+  onOpen,
+  isLoading = false,
+  error,
+}: PolyMarketGridProps) {
+  if (error) {
+    return (
+      <div className="rounded-3xl border border-red-400/40 bg-red-500/10 p-4 text-sm text-red-200">
+        <p className="font-medium">Unable to load Polymarket data</p>
+        <p className="mt-1 opacity-80">{error}</p>
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <div
+            key={index}
+            className="card h-48 animate-pulse rounded-3xl bg-gradient-to-br from-[color:var(--surface-2)] via-[color:var(--surface-3)] to-[color:var(--surface-2)]"
+          />
+        ))}
+      </div>
+    )
+  }
+
+  if (!markets || markets.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-3xl bg-gradient-to-br from-[color:var(--surface)] to-[color:var(--surface-2)] p-6 text-sm text-[color:var(--muted)]">
+        <p>No markets matched the current filters.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {markets.map((market) => (
+        <div
+          key={market.id}
+          className="card flex h-full flex-col justify-between rounded-3xl border border-[color:var(--border)]/50 bg-[color:var(--surface-2)]/60 p-4 shadow-lg shadow-black/5"
+        >
+          <div className="flex flex-col gap-4">
+            <div className="flex items-start justify-between gap-3">
+              <h3 className="line-clamp-2 text-lg font-semibold leading-snug text-[color:var(--text)]">
+                {market.title || "Untitled market"}
+              </h3>
+              <span
+                className={clsx(
+                  "ml-auto rounded-full px-3 py-1 text-xs font-medium capitalize",
+                  getStatusClass(market.status),
+                )}
+              >
+                {market.status || "unknown"}
+              </span>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300">
+                <span className="font-semibold">YES</span>
+                <span>{formatPrice(market.priceYes)}</span>
+              </span>
+              <span className="inline-flex items-center gap-2 rounded-full border border-red-500/40 bg-red-500/10 px-3 py-1 text-xs font-medium text-red-300">
+                <span className="font-semibold">NO</span>
+                <span>{formatPrice(market.priceNo)}</span>
+              </span>
+            </div>
+
+            <dl className="grid grid-cols-2 gap-3 text-xs text-[color:var(--muted)] sm:grid-cols-3">
+              <div>
+                <dt className="font-medium text-[color:var(--muted)]">Volume 24h</dt>
+                <dd className="mt-1 text-sm font-semibold text-[color:var(--text)]">${formatNumber(market.volume24h)}</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-[color:var(--muted)]">Liquidity</dt>
+                <dd className="mt-1 text-sm font-semibold text-[color:var(--text)]">${formatNumber(market.liquidity)}</dd>
+              </div>
+              <div className="sm:col-span-1">
+                <dt className="font-medium text-[color:var(--muted)]">End Date</dt>
+                <dd className="mt-1 text-sm font-semibold text-[color:var(--text)]">{formatDate(market.endDate)}</dd>
+              </div>
+            </dl>
+          </div>
+
+          <div className="mt-6 flex flex-col gap-2 sm:flex-row sm:items-center">
+            <button
+              type="button"
+              onClick={() => onOpen?.(market.id)}
+              className="inline-flex w-full items-center justify-center rounded-full bg-[color:var(--primary)] px-4 py-2 text-sm font-semibold text-white shadow-sm shadow-[color:var(--primary)]/30 transition hover:bg-[color:var(--primary-stronger)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--primary)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)]"
+            >
+              Open
+            </button>
+            <Link
+              href={market.id ? `https://polymarket.com/market/${market.id}` : "https://polymarket.com"}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex w-full items-center justify-center rounded-full border border-[color:var(--primary)]/40 bg-transparent px-4 py-2 text-sm font-semibold text-[color:var(--primary)] transition hover:bg-[color:var(--primary)]/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--primary)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)]"
+            >
+              View on Polymarket
+            </Link>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/shared/SidePanel.tsx
+++ b/src/components/shared/SidePanel.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+
+import { ExternalLink, Share2, Copy, RefreshCcw } from "lucide-react";
+
+import { usePolyMarketDetails } from "@/hooks/usePolyMarketDetails";
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { useToast } from "@/components/ui/use-toast";
+import { useSidePanel } from "@/stores/useSidePanel";
+import type { PolyMarket } from "@/types";
+
+const numberFormatter = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function formatNumber(value?: number | null) {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "—";
+  }
+
+  return numberFormatter.format(value);
+}
+
+function formatDate(value?: string | number | null) {
+  if (!value) return "—";
+
+  const date = typeof value === "string" ? new Date(value) : new Date(value * 1000);
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function normalizeSqlDate(value?: string | number) {
+  if (!value) return "—";
+
+  const raw = typeof value === "number" ? value.toString() : value;
+  if (/^\d{8}$/.test(raw)) {
+    const year = Number(raw.slice(0, 4));
+    const month = Number(raw.slice(4, 6)) - 1;
+    const day = Number(raw.slice(6, 8));
+    const utcDate = new Date(Date.UTC(year, month, day));
+    if (!Number.isNaN(utcDate.getTime())) {
+      return utcDate.toISOString().split("T")[0];
+    }
+  }
+
+  const fallback = new Date(raw);
+  if (!Number.isNaN(fallback.getTime())) {
+    return fallback.toISOString().split("T")[0];
+  }
+
+  return "—";
+}
+
+function EventContent() {
+  const { payload } = useSidePanel();
+  const { toast } = useToast();
+
+  const eventData = React.useMemo(
+    () => (payload?.json && typeof payload.json === "object" ? payload.json : null),
+    [payload?.json],
+  );
+
+  const eventUrl = React.useMemo(() => {
+    const provided = typeof payload?.url === "string" ? payload.url : undefined;
+    if (provided) return provided;
+
+    if (eventData && "SOURCEURL" in eventData && typeof (eventData as Record<string, unknown>).SOURCEURL === "string") {
+      return (eventData as Record<string, string>).SOURCEURL;
+    }
+
+    return undefined;
+  }, [eventData, payload?.url]);
+
+  const eventTitle = React.useMemo(() => {
+    if (typeof payload?.title === "string") return payload.title;
+    if (eventData && "DocumentIdentifier" in eventData && typeof (eventData as Record<string, unknown>).DocumentIdentifier === "string") {
+      return (eventData as Record<string, string>).DocumentIdentifier;
+    }
+    if (eventData && "Actor1Name" in eventData && typeof (eventData as Record<string, unknown>).Actor1Name === "string") {
+      return (eventData as Record<string, string>).Actor1Name;
+    }
+    return undefined;
+  }, [eventData, payload?.title]);
+
+  const eventDateRaw = React.useMemo(() => {
+    if (!eventData) return undefined;
+    const candidate = (eventData as Record<string, unknown>).SQLDATE;
+    return typeof candidate === "string" || typeof candidate === "number" ? candidate : undefined;
+  }, [eventData]);
+
+  const eventDate = React.useMemo(() => normalizeSqlDate(eventDateRaw), [eventDateRaw]);
+
+  const handleShare = React.useCallback(async () => {
+    if (!eventUrl) {
+      toast({
+        title: "No link available",
+        description: "This event does not include a public source URL.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      if (typeof navigator !== "undefined" && navigator.share) {
+        await navigator.share({
+          title: eventTitle?.toString() ?? "GDELT Event",
+          url: eventUrl,
+        });
+        return;
+      }
+
+      if (typeof navigator !== "undefined" && navigator.clipboard) {
+        await navigator.clipboard.writeText(eventUrl);
+        toast({
+          title: "Link copied",
+          description: "Event URL copied to clipboard.",
+        });
+        return;
+      }
+    } catch (error) {
+      console.error("Share failed", error);
+    }
+
+    toast({
+      title: "Share unavailable",
+      description: "We couldn't share this event automatically.",
+      variant: "destructive",
+    });
+  }, [eventTitle, eventUrl, toast]);
+
+  if (!eventData) {
+    return (
+      <div className="card space-y-3 rounded-3xl border border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/60 p-6 text-sm text-[color:var(--muted)]">
+        No event selected.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="card space-y-3 rounded-3xl border border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/70 p-5 shadow-lg shadow-black/5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-wide text-[color:var(--muted)]">Event Date</p>
+            <p className="text-base font-semibold text-[color:var(--text)]">{eventDate}</p>
+          </div>
+          {eventUrl ? (
+            <Link
+              className="inline-flex items-center gap-1 rounded-full border border-[color:var(--primary)]/60 bg-[color:var(--primary)]/10 px-3 py-1 text-xs font-semibold text-[color:var(--primary)] transition hover:bg-[color:var(--primary)]/20"
+              href={eventUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Source
+              <ExternalLink className="h-3.5 w-3.5" />
+            </Link>
+          ) : null}
+        </div>
+        <div className="card compact rounded-2xl border border-dashed border-[color:var(--border)]/60 bg-[color:var(--surface)]/50 p-4 text-xs">
+          <pre className="max-h-80 overflow-y-auto whitespace-pre-wrap text-[color:var(--muted)]">
+            {JSON.stringify(eventData, null, 2)}
+          </pre>
+        </div>
+        <div className="flex items-center justify-end">
+          <Button onClick={handleShare} size="sm" className="rounded-full px-4">
+            <Share2 className="h-4 w-4" /> Share event
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MarketSkeleton() {
+  return (
+    <div className="card space-y-4 rounded-3xl border border-[color:var(--border)]/50 bg-[color:var(--surface-2)]/50 p-5">
+      <div className="h-5 w-1/2 animate-pulse rounded-full bg-[color:var(--surface-3)]/80" />
+      <div className="space-y-2">
+        <div className="h-10 animate-pulse rounded-2xl bg-[color:var(--surface-3)]/70" />
+        <div className="h-10 animate-pulse rounded-2xl bg-[color:var(--surface-3)]/70" />
+      </div>
+      <div className="h-32 animate-pulse rounded-3xl bg-[color:var(--surface-3)]/50" />
+    </div>
+  );
+}
+
+function MarketError({ message }: { message: string }) {
+  return (
+    <div className="card space-y-2 rounded-3xl border border-red-500/50 bg-red-500/10 p-5 text-sm text-red-100">
+      <p className="font-semibold">Unable to load market</p>
+      <p className="text-xs text-red-200">{message}</p>
+    </div>
+  );
+}
+
+function MarketContent({ market }: { market: PolyMarket | null }) {
+  const { toast } = useToast();
+
+  if (!market) {
+    return (
+      <div className="card space-y-3 rounded-3xl border border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/60 p-6 text-sm text-[color:var(--muted)]">
+        Market details are not available.
+      </div>
+    );
+  }
+
+  const polymarketUrl = `https://polymarket.com/market/${market.id}`;
+
+  const handleCopyId = async () => {
+    if (typeof navigator !== "undefined" && navigator.clipboard) {
+      await navigator.clipboard.writeText(market.id);
+      toast({
+        title: "Market ID copied",
+        description: "You can now share or debug this market.",
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="card space-y-4 rounded-3xl border border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/70 p-5 shadow-lg shadow-black/5">
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold text-[color:var(--text)]">{market.title}</h2>
+          <div className="flex flex-wrap gap-2 text-xs text-[color:var(--muted)]">
+            <span className="rounded-full bg-[color:var(--surface-3)]/60 px-3 py-1">
+              Status: <span className="font-semibold text-[color:var(--text)]">{market.status}</span>
+            </span>
+            {market.category ? (
+              <span className="rounded-full bg-[color:var(--surface-3)]/60 px-3 py-1">
+                Category: <span className="font-semibold text-[color:var(--text)]">{market.category}</span>
+              </span>
+            ) : null}
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div className="card compact space-y-1 rounded-2xl border border-[color:var(--primary)]/40 bg-[color:var(--primary)]/10 p-4">
+            <span className="text-xs uppercase tracking-wide text-[color:var(--muted)]">YES</span>
+            <span className="text-xl font-semibold text-emerald-300">
+              {formatNumber(market.priceYes ?? market.tokens.find((token) => token.outcome === "YES")?.price ?? null)}
+            </span>
+          </div>
+          <div className="card compact space-y-1 rounded-2xl border border-red-500/40 bg-red-500/10 p-4">
+            <span className="text-xs uppercase tracking-wide text-[color:var(--muted)]">NO</span>
+            <span className="text-xl font-semibold text-red-200">
+              {formatNumber(market.priceNo ?? market.tokens.find((token) => token.outcome === "NO")?.price ?? null)}
+            </span>
+          </div>
+        </div>
+        <div className="card compact space-y-3 rounded-2xl border border-dashed border-[color:var(--border)]/60 bg-[color:var(--surface)]/60 p-4 text-sm">
+          <div className="flex items-center justify-between">
+            <span className="text-[color:var(--muted)]">24h Volume</span>
+            <span className="font-semibold">{formatNumber(market.volume24h)}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-[color:var(--muted)]">Liquidity</span>
+            <span className="font-semibold">{formatNumber(market.liquidity)}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-[color:var(--muted)]">End Date</span>
+            <span className="font-semibold">{market.endDate ? formatDate(market.endDate) : "—"}</span>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Button asChild size="sm" className="rounded-full px-4">
+            <Link href={polymarketUrl} target="_blank" rel="noopener noreferrer">
+              <ExternalLink className="h-4 w-4" /> Open on Polymarket
+            </Link>
+          </Button>
+          <Button type="button" onClick={handleCopyId} size="sm" variant="outline" className="rounded-full px-4">
+            <Copy className="h-4 w-4" /> Copy Market ID
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SidePanel() {
+  const { isOpen, mode, payload, closePanel } = useSidePanel();
+  const marketId = mode === "market" ? payload?.id : undefined;
+  const {
+    data: marketData,
+    isLoading: isMarketLoading,
+    isError: isMarketError,
+    error: marketError,
+    refetch,
+  } = usePolyMarketDetails({ id: marketId });
+
+  const handleOpenChange = React.useCallback(
+    (open: boolean) => {
+      if (!open) {
+        closePanel();
+      }
+    },
+    [closePanel],
+  );
+
+  return (
+    <Drawer open={isOpen} onOpenChange={handleOpenChange}>
+      <DrawerContent className="w-full max-w-[420px] border-l border-[color:var(--border)]/60 bg-[color:var(--surface)]/95">
+        <DrawerHeader className="flex flex-col gap-1">
+          <DrawerTitle>
+            {mode === "event" ? "Event Details" : "Market Details"}
+          </DrawerTitle>
+        </DrawerHeader>
+        <div className="flex-1 overflow-y-auto px-6 py-5">
+          {mode === "event" ? (
+            <EventContent />
+          ) : isMarketLoading ? (
+            <MarketSkeleton />
+          ) : isMarketError ? (
+            <div className="space-y-4">
+              <MarketError message={marketError instanceof Error ? marketError.message : "Unknown error"} />
+              <Button
+                type="button"
+                onClick={() => refetch()}
+                size="sm"
+                variant="outline"
+                className="rounded-full"
+              >
+                <RefreshCcw className="h-4 w-4" /> Retry
+              </Button>
+            </div>
+          ) : (
+            <MarketContent market={marketData?.market ?? null} />
+          )}
+        </div>
+        <DrawerFooter className="flex items-center justify-end">
+          <DrawerClose asChild>
+            <Button variant="ghost">Close</Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/components/system/ActivityPanel.tsx
+++ b/src/components/system/ActivityPanel.tsx
@@ -1,0 +1,155 @@
+"use client"
+
+import clsx from "clsx"
+
+interface DatasetStatus {
+  id: string
+  label: string
+  lastFetched?: string
+  status?: "green" | "yellow" | "red"
+  fallback?: string | null
+  enabled?: boolean
+}
+
+interface RecentQuery {
+  query: string
+  timestamp: string
+  dataset?: string
+}
+
+interface ActivityPanelProps {
+  datasets?: DatasetStatus[]
+  recentQueries?: RecentQuery[]
+  isLoading?: boolean
+  error?: string | null
+}
+
+const STATUS_ICON: Record<NonNullable<DatasetStatus["status"]>, string> = {
+  green: "🟢",
+  yellow: "🟡",
+  red: "🔴",
+}
+
+const formatTimestamp = (value?: string) => {
+  if (!value) return "—"
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toISOString().replace("T", " ").slice(0, 19)
+}
+
+export function ActivityPanel({ datasets = [], recentQueries = [], isLoading = false, error }: ActivityPanelProps) {
+  if (error) {
+    return (
+      <div className="card compact rounded-2xl border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-100">
+        {error}
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="card compact space-y-4 rounded-2xl bg-gradient-to-br from-[color:var(--surface-2)] via-[color:var(--surface-3)] to-[color:var(--surface-2)] p-4">
+        <div className="h-5 w-48 animate-pulse rounded-full bg-white/10" />
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={`dataset-${index}`} className="h-5 w-full animate-pulse rounded-full bg-white/10" />
+          ))}
+        </div>
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={`query-${index}`} className="h-4 w-full animate-pulse rounded-full bg-white/10" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  const hasContent = datasets.length > 0 || recentQueries.length > 0
+
+  if (!hasContent) {
+    return (
+      <div className="card compact rounded-2xl border border-dashed border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/50 p-4 text-sm text-[color:var(--muted)]">
+        Activity will appear here once datasets begin syncing.
+      </div>
+    )
+  }
+
+  return (
+    <div className="card compact space-y-6 rounded-2xl border border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/60 p-4 shadow-sm shadow-black/5">
+      <header>
+        <h3 className="text-base font-semibold text-[color:var(--text)]">System activity</h3>
+        <p className="text-xs text-[color:var(--muted)]">Latest synchronization status across connected datasets.</p>
+      </header>
+
+      {datasets.length > 0 && (
+        <section className="space-y-3">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-[color:var(--muted)]">Dataset health</h4>
+          <ul className="space-y-2 text-sm">
+            {datasets.map((dataset) => {
+              const statusIcon = dataset.status ? STATUS_ICON[dataset.status] : ""
+              return (
+                <li
+                  key={dataset.id}
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-xl bg-[color:var(--surface-3)]/40 px-3 py-2"
+                >
+                  <div className="flex flex-col">
+                    <span className="font-medium text-[color:var(--text)]">
+                      {statusIcon && <span className="mr-2 align-middle text-lg">{statusIcon}</span>}
+                      {dataset.label}
+                    </span>
+                    <span className="font-mono text-xs text-[color:var(--muted)]">
+                      Last fetch: {formatTimestamp(dataset.lastFetched)}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 text-xs">
+                    {dataset.fallback && (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 font-medium text-amber-300">
+                        ⚠️ {dataset.fallback}
+                      </span>
+                    )}
+                    <span
+                      className={clsx(
+                        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 font-medium",
+                        dataset.enabled
+                          ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-300"
+                          : "border-red-400/40 bg-red-500/10 text-red-200"
+                      )}
+                    >
+                      {dataset.enabled ? "Enabled" : "Disabled"}
+                    </span>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        </section>
+      )}
+
+      {recentQueries.length > 0 && (
+        <section className="space-y-3">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-[color:var(--muted)]">Recent queries</h4>
+          <ul className="space-y-2 text-xs">
+            {recentQueries.slice(0, 6).map((item, index) => (
+              <li
+                key={`${item.timestamp}-${index}`}
+                className="flex items-center justify-between rounded-xl border border-[color:var(--border)]/50 bg-[color:var(--surface-3)]/30 px-3 py-2"
+              >
+                <span className="truncate text-[color:var(--text)]">
+                  {item.dataset ? (
+                    <span className="mr-2 rounded-full bg-[color:var(--primary)]/15 px-2 py-0.5 font-semibold text-[color:var(--primary)]">
+                      {item.dataset}
+                    </span>
+                  ) : null}
+                  {item.query}
+                </span>
+                <span className="font-mono text-[color:var(--muted)]">{formatTimestamp(item.timestamp)}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  )
+}
+
+export default ActivityPanel

--- a/src/components/twitter/TwitterPlaceholder.tsx
+++ b/src/components/twitter/TwitterPlaceholder.tsx
@@ -29,10 +29,12 @@ function formatTimestamp(timestamp?: string) {
       hour: "2-digit",
       minute: "2-digit",
     });
-  } catch (error) {
+  } catch {
     return timestamp;
   }
 }
+
+type TwitterApiResponse = PlaceholderTweet[] | { data?: PlaceholderTweet[] | null };
 
 function TweetSkeleton() {
   return (
@@ -106,7 +108,7 @@ export function TwitterPlaceholder({ comingSoon }: TwitterPlaceholderProps) {
           const message = await response.text();
           throw new Error(message || "Unable to load Twitter data");
         }
-        return response.json();
+        return response.json() as Promise<TwitterApiResponse>;
       })
       .then((data) => {
         if (!isMounted) {
@@ -115,8 +117,8 @@ export function TwitterPlaceholder({ comingSoon }: TwitterPlaceholderProps) {
 
         const normalized: PlaceholderTweet[] = Array.isArray(data)
           ? data
-          : Array.isArray((data as any)?.data)
-          ? (data as any).data
+          : Array.isArray(data?.data)
+          ? data.data ?? []
           : [];
 
         setTweets(normalized);

--- a/src/components/twitter/TwitterPlaceholder.tsx
+++ b/src/components/twitter/TwitterPlaceholder.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface TwitterPlaceholderProps {
+  comingSoon: boolean;
+}
+
+interface PlaceholderTweet {
+  id?: string;
+  text?: string;
+  author?: string;
+  createdAt?: string;
+  url?: string;
+}
+
+const skeletonTweets = Array.from({ length: 3 });
+
+function formatTimestamp(timestamp?: string) {
+  if (!timestamp) {
+    return "";
+  }
+
+  try {
+    const date = new Date(timestamp);
+    return date.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch (error) {
+    return timestamp;
+  }
+}
+
+function TweetSkeleton() {
+  return (
+    <div className="flex animate-pulse gap-3 rounded-2xl border border-[color:var(--surface-3)]/20 bg-gradient-to-br from-[color:var(--surface-2)] to-[color:var(--surface-3)] p-3 shadow-inner shadow-black/5">
+      <div className="h-10 w-10 rounded-full bg-[color:var(--surface-4)]" />
+      <div className="flex-1 space-y-2">
+        <div className="h-3 w-32 rounded-full bg-[color:var(--surface-4)]" />
+        <div className="h-3 w-full rounded-full bg-[color:var(--surface-4)]" />
+        <div className="h-3 w-5/6 rounded-full bg-[color:var(--surface-4)]" />
+      </div>
+    </div>
+  );
+}
+
+function TweetCard({ tweet }: { tweet: PlaceholderTweet }) {
+  return (
+    <article className="group flex flex-col gap-2 rounded-2xl border border-[color:var(--surface-3)]/20 bg-gradient-to-br from-[color:var(--surface-2)] to-[color:var(--surface-3)] p-3 shadow-lg shadow-black/5 transition hover:border-[color:var(--primary)]/40 hover:shadow-[0_20px_45px_-30px_var(--primary)]">
+      <header className="flex items-center justify-between gap-3 text-sm">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="h-10 w-10 flex-shrink-0 rounded-full bg-[color:var(--primary)]/20" />
+          <div className="min-w-0">
+            <p className="truncate font-medium text-[color:var(--text)]">
+              {tweet.author ?? "Unknown handle"}
+            </p>
+            {tweet.createdAt ? (
+              <p className="text-xs text-[color:var(--muted)]">{formatTimestamp(tweet.createdAt)}</p>
+            ) : null}
+          </div>
+        </div>
+        {tweet.url ? (
+          <a
+            href={tweet.url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center rounded-full border border-[color:var(--surface-4)] bg-[color:var(--surface)] px-3 py-1 text-xs font-medium text-[color:var(--primary)] transition hover:border-[color:var(--primary)] hover:bg-[color:var(--primary)]/10"
+          >
+            View
+          </a>
+        ) : null}
+      </header>
+      <p className="line-clamp-4 text-sm leading-relaxed text-[color:var(--muted-foreground)]">
+        {tweet.text ?? "No summary available yet."}
+      </p>
+    </article>
+  );
+}
+
+export function TwitterPlaceholder({ comingSoon }: TwitterPlaceholderProps) {
+  const [tweets, setTweets] = useState<PlaceholderTweet[]>([]);
+  const [isLoading, setIsLoading] = useState(!comingSoon);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (comingSoon) {
+      setIsLoading(false);
+      setError(null);
+      setTweets([]);
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    fetch("/api/twitter")
+      .then(async (response) => {
+        if (!response.ok) {
+          const message = await response.text();
+          throw new Error(message || "Unable to load Twitter data");
+        }
+        return response.json();
+      })
+      .then((data) => {
+        if (!isMounted) {
+          return;
+        }
+
+        const normalized: PlaceholderTweet[] = Array.isArray(data)
+          ? data
+          : Array.isArray((data as any)?.data)
+          ? (data as any).data
+          : [];
+
+        setTweets(normalized);
+      })
+      .catch((fetchError: unknown) => {
+        if (!isMounted) {
+          return;
+        }
+        const message = fetchError instanceof Error ? fetchError.message : "Unknown error";
+        setError(message);
+      })
+      .finally(() => {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [comingSoon]);
+
+  return (
+    <section className="card relative flex flex-col gap-4 p-4">
+      <header className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-[color:var(--text)]">Twitter Signals</h2>
+          <p className="text-sm text-[color:var(--muted)]">
+            Curated market intelligence sourced from verified feeds.
+          </p>
+        </div>
+      </header>
+
+      {comingSoon ? (
+        <div className="space-y-4">
+          <div className="rounded-full bg-[color:var(--primary)]/15 px-3 py-1 text-sm font-medium text-[color:var(--primary)]">
+            Twitter Integration Coming Soon
+          </div>
+          <div className="space-y-3">
+            {skeletonTweets.map((_, index) => (
+              <TweetSkeleton key={index} />
+            ))}
+          </div>
+        </div>
+      ) : isLoading ? (
+        <div className="space-y-3">
+          {skeletonTweets.map((_, index) => (
+            <TweetSkeleton key={index} />
+          ))}
+        </div>
+      ) : error ? (
+        <div className="rounded-2xl border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">
+          Unable to load Twitter data.
+          <span className="block text-xs opacity-80">{error}</span>
+        </div>
+      ) : tweets.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-[color:var(--surface-4)]/60 bg-[color:var(--surface-2)]/40 p-6 text-center text-sm text-[color:var(--muted)]">
+          No Twitter updates available yet.
+        </div>
+      ) : (
+        <div className="grid gap-3">
+          {tweets.map((tweet, index) => (
+            <TweetCard key={tweet.id ?? tweet.url ?? `${tweet.author ?? "tweet"}-${index}`} tweet={tweet} />
+          ))}
+        </div>
+      )}
+
+      {!comingSoon && tweets.length === 0 && !isLoading && !error ? (
+        <p className="text-center text-xs text-[color:var(--muted)]">
+          Connect your Twitter credentials to surface market chatter once the integration launches.
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+export default TwitterPlaceholder;

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer flex h-4 w-4 shrink-0 items-center justify-center rounded-md border border-[color:var(--border)]/70",
+      "bg-[color:var(--surface-2)]/80 shadow-inner transition",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:var(--primary)]/45 focus-visible:ring-offset-[color:var(--surface)]",
+      "data-[state=checked]:border-[color:var(--primary)] data-[state=checked]:bg-[color:var(--primary)]",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className="flex items-center justify-center text-[color:var(--surface)]">
+      <Check className="h-3 w-3" strokeWidth={3} />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import * as React from "react";
+import * as DrawerPrimitive from "@radix-ui/react-dialog";
+
+import { cn } from "@/lib/utils";
+
+const Drawer = DrawerPrimitive.Root;
+const DrawerTrigger = DrawerPrimitive.Trigger;
+const DrawerPortal = DrawerPrimitive.Portal;
+const DrawerClose = DrawerPrimitive.Close;
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm transition-all data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-y-0 right-0 z-50 flex h-full w-full max-w-[420px] flex-col border-l border-border/60 bg-[var(--surface)] shadow-2xl transition-all data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=open]:animate-in data-[state=open]:slide-in-from-right",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+));
+DrawerContent.displayName = DrawerPrimitive.Content.displayName;
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "border-b border-border/70 px-6 py-4",
+      className,
+    )}
+    {...props}
+  />
+);
+DrawerHeader.displayName = "DrawerHeader";
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("border-t border-border/70 px-6 py-4", className)}
+    {...props}
+  />
+);
+DrawerFooter.displayName = "DrawerFooter";
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-[var(--text)]", className)}
+    {...props}
+  />
+));
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-[var(--muted)]", className)}
+    {...props}
+  />
+));
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
+
+export {
+  Drawer,
+  DrawerTrigger,
+  DrawerContent,
+  DrawerClose,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+const SelectGroup = SelectPrimitive.Group;
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "surface-input flex h-10 w-full items-center justify-between rounded-2xl border border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/80 px-3 py-2 text-sm text-[color:var(--text)] transition",
+      "hover:border-[color:var(--primary)]/40 hover:bg-[color:var(--primary)]/10",
+      "focus:outline-none focus:ring-2 focus:ring-[color:var(--primary)]/45",
+      "data-[placeholder]:text-[color:var(--muted)]",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 text-[color:var(--muted)]" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-50 overflow-hidden rounded-2xl border border-[color:var(--border)]/60 bg-[color:var(--surface-3)] text-[color:var(--text)] shadow-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-2",
+          position === "popper" && "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-3 py-1.5 text-xs font-medium text-[color:var(--muted)] uppercase", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-xl px-3 py-2 text-sm outline-none transition",
+      "focus:bg-[color:var(--primary)]/15 focus:text-[color:var(--text)]",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-4 w-4 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-2 my-1 h-px bg-[color:var(--border)]/60", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+};

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-full bg-[var(--surface-3)] p-1 text-muted-foreground shadow-inner",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-full px-4 py-1.5 text-sm font-medium transition-all data-[state=active]:bg-[var(--surface)] data-[state=active]:text-foreground data-[state=active]:shadow",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn("mt-4 focus-visible:outline-none", className)}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/hooks/__tests__/useGdeltContext.test.ts
+++ b/src/hooks/__tests__/useGdeltContext.test.ts
@@ -1,0 +1,24 @@
+import { fetchGdeltContextData } from "../useGdeltContext";
+import { normalizeGdeltDate } from "../utils";
+
+describe("useGdeltContext utilities", () => {
+  it("normalizes YYYYMMDD dates to ISO format", () => {
+    expect(normalizeGdeltDate("20250831")).toBe("2025-08-31");
+  });
+
+  it("propagates 365 day guard errors", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ status: "error", message: "Daily queries limited to 365 days" }),
+      text: async () => "",
+    });
+
+    await expect(
+      fetchGdeltContextData(
+        { keywords: ["test"], dateStart: "20240101", dateEnd: "20241231", limit: 500, includeInsights: true },
+        fetchMock,
+      ),
+    ).rejects.toThrow("Daily queries limited to 365 days");
+  });
+});

--- a/src/hooks/__tests__/useGdeltCountry.test.ts
+++ b/src/hooks/__tests__/useGdeltCountry.test.ts
@@ -1,0 +1,20 @@
+import { fetchGdeltCountry } from "../useGdeltCountry";
+
+describe("useGdeltCountry", () => {
+  it("logs service unavailability", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => "",
+    });
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      fetchGdeltCountry({ country: "US", dateStart: "20240101", dateEnd: "20240131" }, fetchMock),
+    ).rejects.toThrow("Service unavailable");
+
+    expect(consoleSpy).toHaveBeenCalledWith("Service unavailable");
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/hooks/__tests__/usePolySearch.test.ts
+++ b/src/hooks/__tests__/usePolySearch.test.ts
@@ -1,0 +1,21 @@
+import { normalizeMarket } from "../utils";
+
+describe("normalizeMarket", () => {
+  it("captures YES/NO prices", () => {
+    const market = normalizeMarket({
+      id: "1",
+      title: "Test",
+      endDate: null,
+      volume24h: 0,
+      liquidity: 0,
+      status: "open",
+      tokens: [
+        { id: "yes", outcome: "YES", price: 0.6 },
+        { id: "no", outcome: "NO", price: 0.4 },
+      ],
+    });
+
+    expect(market.priceYes).toBe(0.6);
+    expect(market.priceNo).toBe(0.4);
+  });
+});

--- a/src/hooks/useGdeltBBVA.ts
+++ b/src/hooks/useGdeltBBVA.ts
@@ -1,0 +1,99 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { useGlobalFilters } from "@/stores/useGlobalFilters";
+
+import { commonQueryOptions, createAbortSignal } from "./utils";
+
+export type UseGdeltBBVAParams = {
+  actor1?: string;
+  actor2?: string;
+  dateStart?: string;
+  dateEnd?: string;
+  includeTotal?: boolean;
+  cameoCodes?: string;
+};
+
+export async function fetchGdeltBBVA(
+  params: Required<Pick<UseGdeltBBVAParams, "actor1" | "actor2" | "dateStart" | "dateEnd">> &
+    Pick<UseGdeltBBVAParams, "includeTotal" | "cameoCodes">,
+  fetchImpl: typeof fetch = fetch,
+  abortSignal?: AbortSignal,
+) {
+  const searchParams = new URLSearchParams();
+  searchParams.set("action", "bilateral_conflict_coverage");
+  searchParams.set("mode", "artlist");
+  searchParams.set("format", "json");
+  searchParams.set("actor1_code", params.actor1);
+  searchParams.set("actor2_code", params.actor2);
+  searchParams.set("date_start", params.dateStart);
+  searchParams.set("date_end", params.dateEnd);
+  searchParams.set("include_total", String(params.includeTotal ?? false));
+  if (params.cameoCodes) {
+    searchParams.set("cameo_codes", params.cameoCodes);
+  }
+
+  const response = await fetchImpl(`/api/gdelt?${searchParams.toString()}`, {
+    signal: createAbortSignal(abortSignal),
+  });
+
+  if (!response.ok) {
+    if (response.status === 503) {
+      console.error("Service unavailable");
+      throw new Error("Service unavailable");
+    }
+
+    const message = await response.text();
+    throw new Error(message || "Failed to load BBVA data");
+  }
+
+  return response.json();
+}
+
+export function useGdeltBBVA(params: UseGdeltBBVAParams) {
+  const globalDateStart = useGlobalFilters((state) => state.dateStart);
+  const globalDateEnd = useGlobalFilters((state) => state.dateEnd);
+
+  const queryParams = useMemo(() => ({
+    actor1: params.actor1 ?? "",
+    actor2: params.actor2 ?? "",
+    dateStart: params.dateStart ?? globalDateStart,
+    dateEnd: params.dateEnd ?? globalDateEnd,
+    includeTotal: params.includeTotal ?? false,
+    cameoCodes: params.cameoCodes,
+  }), [
+    globalDateEnd,
+    globalDateStart,
+    params.actor1,
+    params.actor2,
+    params.cameoCodes,
+    params.dateEnd,
+    params.dateStart,
+    params.includeTotal,
+  ]);
+
+  const enabled =
+    Boolean(queryParams.actor1) &&
+    Boolean(queryParams.actor2) &&
+    Boolean(queryParams.dateStart) &&
+    Boolean(queryParams.dateEnd);
+
+  return useQuery({
+    queryKey: ["gdelt", "bbva", queryParams],
+    queryFn: ({ signal }) =>
+      fetchGdeltBBVA(
+        {
+          actor1: queryParams.actor1,
+          actor2: queryParams.actor2,
+          dateStart: queryParams.dateStart,
+          dateEnd: queryParams.dateEnd,
+          includeTotal: queryParams.includeTotal,
+          cameoCodes: queryParams.cameoCodes,
+        },
+        fetch,
+        signal,
+      ),
+    enabled,
+    ...commonQueryOptions,
+  });
+}

--- a/src/hooks/useGdeltBilateral.ts
+++ b/src/hooks/useGdeltBilateral.ts
@@ -1,0 +1,87 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { useGlobalFilters } from "@/stores/useGlobalFilters";
+
+import { commonQueryOptions, createAbortSignal } from "./utils";
+
+export type UseGdeltBilateralParams = {
+  country1?: string;
+  country2?: string;
+  dateStart?: string;
+  dateEnd?: string;
+};
+
+export async function fetchGdeltBilateral(
+  params: Required<UseGdeltBilateralParams>,
+  fetchImpl: typeof fetch = fetch,
+  abortSignal?: AbortSignal,
+) {
+  const searchParams = new URLSearchParams();
+  searchParams.set("action", "bilateral");
+  searchParams.set("mode", "artlist");
+  searchParams.set("format", "json");
+  searchParams.set("country1", params.country1);
+  searchParams.set("country2", params.country2);
+  searchParams.set("date_start", params.dateStart);
+  searchParams.set("date_end", params.dateEnd);
+  searchParams.set("granularity", "daily");
+
+  const response = await fetchImpl(`/api/gdelt?${searchParams.toString()}`, {
+    signal: createAbortSignal(abortSignal),
+  });
+
+  if (!response.ok) {
+    if (response.status === 503) {
+      console.error("Service unavailable");
+      throw new Error("Service unavailable");
+    }
+
+    const message = await response.text();
+    throw new Error(message || "Failed to load GDELT bilateral data");
+  }
+
+  return response.json();
+}
+
+export function useGdeltBilateral(params: UseGdeltBilateralParams) {
+  const globalDateStart = useGlobalFilters((state) => state.dateStart);
+  const globalDateEnd = useGlobalFilters((state) => state.dateEnd);
+
+  const queryParams = useMemo(() => ({
+    country1: params.country1 ?? "",
+    country2: params.country2 ?? "",
+    dateStart: params.dateStart ?? globalDateStart,
+    dateEnd: params.dateEnd ?? globalDateEnd,
+  }), [
+    globalDateEnd,
+    globalDateStart,
+    params.country1,
+    params.country2,
+    params.dateEnd,
+    params.dateStart,
+  ]);
+
+  const enabled =
+    Boolean(queryParams.country1) &&
+    Boolean(queryParams.country2) &&
+    Boolean(queryParams.dateStart) &&
+    Boolean(queryParams.dateEnd);
+
+  return useQuery({
+    queryKey: ["gdelt", "bilateral", queryParams],
+    queryFn: ({ signal }) =>
+      fetchGdeltBilateral(
+        {
+          country1: queryParams.country1,
+          country2: queryParams.country2,
+          dateStart: queryParams.dateStart,
+          dateEnd: queryParams.dateEnd,
+        },
+        fetch,
+        signal,
+      ),
+    enabled,
+    ...commonQueryOptions,
+  });
+}

--- a/src/hooks/useGdeltContext.ts
+++ b/src/hooks/useGdeltContext.ts
@@ -1,0 +1,157 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { useGlobalFilters } from "@/stores/useGlobalFilters";
+import type { GdeltEvent, GdeltInsights, GdeltSeriesPoint } from "@/types";
+
+import { commonQueryOptions, createAbortSignal, normalizeGdeltDate } from "./utils";
+
+export type GdeltContextResult = {
+  series: GdeltSeriesPoint[];
+  events: GdeltEvent[];
+  insights: GdeltInsights;
+};
+
+export type UseGdeltContextParams = {
+  keywords?: string[];
+  dateStart?: string;
+  dateEnd?: string;
+  limit?: number;
+  includeInsights?: boolean;
+};
+
+const defaultMockContext: GdeltContextResult = {
+  series: [
+    {
+      date: "2025-10-01",
+      conflict_events: 100,
+    },
+  ],
+  events: [],
+  insights: {},
+};
+
+export async function fetchGdeltContextData(
+  params: Required<Pick<UseGdeltContextParams, "keywords" | "dateStart" | "dateEnd">> &
+    Pick<UseGdeltContextParams, "limit" | "includeInsights">,
+  fetchImpl: typeof fetch = fetch,
+  abortSignal?: AbortSignal,
+): Promise<GdeltContextResult> {
+  const searchParams = new URLSearchParams();
+  searchParams.set("action", "context");
+  searchParams.set("mode", "artlist");
+  searchParams.set("format", "json");
+  searchParams.set("keywords", params.keywords.join(","));
+  searchParams.set("date_start", params.dateStart);
+  searchParams.set("date_end", params.dateEnd);
+  searchParams.set("include_insights", String(params.includeInsights ?? true));
+  searchParams.set("limit", String(params.limit ?? 500));
+
+  const response = await fetchImpl(`/api/gdelt?${searchParams.toString()}`, {
+    signal: createAbortSignal(abortSignal),
+  });
+
+  if (!response.ok) {
+    if (response.status === 503) {
+      console.error("Service unavailable");
+      return defaultMockContext;
+    }
+
+    let message = "GDELT error";
+    try {
+      const errorBody = await response.json();
+      if (errorBody?.message) {
+        message = errorBody.message;
+      } else if (typeof errorBody?.status === "string") {
+        message = errorBody.status;
+      }
+    } catch (error) {
+      const fallbackMessage = await response.text().catch(() => "");
+      if (fallbackMessage) {
+        message = fallbackMessage;
+      }
+    }
+
+    throw new Error(message);
+  }
+
+  const data = await response.json();
+  const items: any[] = Array.isArray(data?.data) ? data.data : [];
+
+  const series: GdeltSeriesPoint[] = items.map((item) => ({
+    date: normalizeGdeltDate(item?.DayDate ?? item?.SQLDATE ?? item?.date),
+    conflict_events: typeof item?.conflict_events === "number" ? item.conflict_events : undefined,
+    avg_sentiment: typeof item?.avg_sentiment === "number" ? item.avg_sentiment : undefined,
+    avg_impact: typeof item?.avg_impact === "number" ? item.avg_impact : undefined,
+    interaction_count: typeof item?.interaction_count === "number" ? item.interaction_count : undefined,
+    relative_coverage: typeof item?.relative_coverage === "number" ? item.relative_coverage : undefined,
+  }));
+
+  const events: GdeltEvent[] = items.map((item) => ({
+    SQLDATE: item?.SQLDATE ?? item?.DayDate ?? "",
+    SOURCEURL: item?.SOURCEURL ?? "",
+    Actor1CountryCode: item?.Actor1CountryCode,
+    EventCode: item?.EventCode,
+    AvgTone: typeof item?.AvgTone === "number" ? item.AvgTone : undefined,
+    ...item,
+  }));
+
+  const insights: GdeltInsights = (data?.insights ?? {}) as GdeltInsights;
+
+  return {
+    series,
+    events,
+    insights,
+  };
+}
+
+export function useGdeltContext(params: UseGdeltContextParams = {}) {
+  const globalKeywords = useGlobalFilters((state) => state.keywords);
+  const globalDateStart = useGlobalFilters((state) => state.dateStart);
+  const globalDateEnd = useGlobalFilters((state) => state.dateEnd);
+
+  const queryParams = useMemo(() => {
+    const keywords = params.keywords?.length ? params.keywords : globalKeywords;
+    const dateStart = params.dateStart ?? globalDateStart;
+    const dateEnd = params.dateEnd ?? globalDateEnd;
+
+    return {
+      keywords,
+      dateStart,
+      dateEnd,
+      limit: params.limit ?? 500,
+      includeInsights: params.includeInsights ?? true,
+    };
+  }, [
+    globalDateEnd,
+    globalDateStart,
+    globalKeywords,
+    params.dateEnd,
+    params.dateStart,
+    params.includeInsights,
+    params.keywords,
+    params.limit,
+  ]);
+
+  return useQuery({
+    queryKey: ["gdelt", "context", queryParams],
+    queryFn: ({ signal }) =>
+      fetchGdeltContextData(
+        {
+          keywords: queryParams.keywords,
+          dateStart: queryParams.dateStart,
+          dateEnd: queryParams.dateEnd,
+          limit: queryParams.limit,
+          includeInsights: queryParams.includeInsights,
+        },
+        fetch,
+        signal,
+      ),
+    enabled:
+      Array.isArray(queryParams.keywords) &&
+      queryParams.keywords.length > 0 &&
+      Boolean(queryParams.dateStart) &&
+      Boolean(queryParams.dateEnd),
+    ...commonQueryOptions,
+  });
+}

--- a/src/hooks/useGdeltCountry.ts
+++ b/src/hooks/useGdeltCountry.ts
@@ -1,0 +1,81 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { useGlobalFilters } from "@/stores/useGlobalFilters";
+
+import { commonQueryOptions, createAbortSignal } from "./utils";
+
+export type UseGdeltCountryParams = {
+  country?: string;
+  dateStart?: string;
+  dateEnd?: string;
+};
+
+export async function fetchGdeltCountry(
+  params: Required<UseGdeltCountryParams>,
+  fetchImpl: typeof fetch = fetch,
+  abortSignal?: AbortSignal,
+) {
+  const searchParams = new URLSearchParams();
+  searchParams.set("action", "country");
+  searchParams.set("mode", "artlist");
+  searchParams.set("format", "json");
+  searchParams.set("country", params.country);
+  searchParams.set("date_start", params.dateStart);
+  searchParams.set("date_end", params.dateEnd);
+  searchParams.set("time_unit", "day");
+
+  const response = await fetchImpl(`/api/gdelt?${searchParams.toString()}`, {
+    signal: createAbortSignal(abortSignal),
+  });
+
+  if (!response.ok) {
+    if (response.status === 503) {
+      console.error("Service unavailable");
+      throw new Error("Service unavailable");
+    }
+
+    let message = await response.text();
+    if (!message) {
+      try {
+        const body = await response.json();
+        message = body?.message ?? "Failed to load GDELT country data";
+      } catch (error) {
+        message = "Failed to load GDELT country data";
+      }
+    }
+
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+export function useGdeltCountry(params: UseGdeltCountryParams) {
+  const globalDateStart = useGlobalFilters((state) => state.dateStart);
+  const globalDateEnd = useGlobalFilters((state) => state.dateEnd);
+
+  const queryParams = useMemo(() => ({
+    country: params.country ?? "",
+    dateStart: params.dateStart ?? globalDateStart,
+    dateEnd: params.dateEnd ?? globalDateEnd,
+  }), [globalDateEnd, globalDateStart, params.country, params.dateEnd, params.dateStart]);
+
+  const enabled = Boolean(queryParams.country && queryParams.dateStart && queryParams.dateEnd);
+
+  return useQuery({
+    queryKey: ["gdelt", "country", queryParams],
+    queryFn: ({ signal }) =>
+      fetchGdeltCountry(
+        {
+          country: queryParams.country,
+          dateStart: queryParams.dateStart,
+          dateEnd: queryParams.dateEnd,
+        },
+        fetch,
+        signal,
+      ),
+    enabled,
+    ...commonQueryOptions,
+  });
+}

--- a/src/hooks/useGdeltCountry.ts
+++ b/src/hooks/useGdeltCountry.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 
+import type { GdeltContextApiResponse } from "@/types";
 import { useGlobalFilters } from "@/stores/useGlobalFilters";
 
 import { commonQueryOptions, createAbortSignal } from "./utils";
@@ -38,9 +39,10 @@ export async function fetchGdeltCountry(
     let message = await response.text();
     if (!message) {
       try {
-        const body = await response.json();
+        const body = (await response.json()) as GdeltContextApiResponse;
         message = body?.message ?? "Failed to load GDELT country data";
-      } catch (error) {
+      } catch (parseError) {
+        console.error("Failed to parse GDELT country error response", parseError);
         message = "Failed to load GDELT country data";
       }
     }
@@ -48,7 +50,7 @@ export async function fetchGdeltCountry(
     throw new Error(message);
   }
 
-  return response.json();
+  return response.json() as Promise<GdeltContextApiResponse>;
 }
 
 export function useGdeltCountry(params: UseGdeltCountryParams) {

--- a/src/hooks/usePolyMarketDetails.ts
+++ b/src/hooks/usePolyMarketDetails.ts
@@ -1,0 +1,63 @@
+import { useQuery } from "@tanstack/react-query";
+
+import type { PolyMarket } from "@/types";
+
+import { commonQueryOptions, createAbortSignal, normalizeMarket } from "./utils";
+
+export type UsePolyMarketDetailsParams = {
+  id?: string;
+};
+
+export type PolyMarketDetailsResult = {
+  market: PolyMarket | null;
+  [key: string]: unknown;
+};
+
+export async function fetchPolyMarketDetails(
+  params: Required<UsePolyMarketDetailsParams>,
+  fetchImpl: typeof fetch = fetch,
+  abortSignal?: AbortSignal,
+): Promise<PolyMarketDetailsResult> {
+  const response = await fetchImpl(`/api/poly/market?id=${params.id}`, {
+    signal: createAbortSignal(abortSignal),
+  });
+
+  if (!response.ok) {
+    if (response.status === 503) {
+      console.error("Service unavailable");
+      throw new Error("Service unavailable");
+    }
+
+    const message = await response.text();
+    throw new Error(message || "Failed to load Poly market details");
+  }
+
+  const data = await response.json();
+  const marketData = data?.market ?? data;
+
+  return {
+    ...data,
+    market: marketData ? normalizeMarket(marketData) : null,
+  };
+}
+
+export function usePolyMarketDetails(params: UsePolyMarketDetailsParams) {
+  return useQuery({
+    queryKey: ["poly", "market", params?.id],
+    queryFn: ({ signal }) => {
+      if (!params?.id) {
+        throw new Error("Market id is required");
+      }
+
+      return fetchPolyMarketDetails(
+        {
+          id: params.id,
+        },
+        fetch,
+        signal,
+      );
+    },
+    enabled: Boolean(params?.id),
+    ...commonQueryOptions,
+  });
+}

--- a/src/hooks/usePolySearch.ts
+++ b/src/hooks/usePolySearch.ts
@@ -1,0 +1,107 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { useGlobalFilters } from "@/stores/useGlobalFilters";
+import type { PolyMarket } from "@/types";
+
+import { commonQueryOptions, createAbortSignal, normalizeMarket } from "./utils";
+
+type PolySortOption = "volume24h" | "liquidity" | "endDate";
+
+export type UsePolySearchParams = {
+  q?: string;
+  active?: boolean;
+  limit?: number;
+  category?: string;
+  sort?: PolySortOption;
+};
+
+export type PolySearchResult = {
+  markets: PolyMarket[];
+  [key: string]: unknown;
+};
+
+export async function fetchPolySearch(
+  params: Required<Pick<UsePolySearchParams, "q">> &
+    Pick<UsePolySearchParams, "active" | "limit" | "category" | "sort">,
+  fetchImpl: typeof fetch = fetch,
+  abortSignal?: AbortSignal,
+): Promise<PolySearchResult> {
+  const searchParams = new URLSearchParams();
+  searchParams.set("q", params.q);
+  searchParams.set("active", String(params.active ?? true));
+  searchParams.set("limit", String(params.limit ?? 30));
+  if (params.category) {
+    searchParams.set("category", params.category);
+  }
+  searchParams.set("sort", params.sort ?? "volume24h");
+
+  const response = await fetchImpl(`/api/poly?${searchParams.toString()}`, {
+    signal: createAbortSignal(abortSignal),
+  });
+
+  if (!response.ok) {
+    if (response.status === 503) {
+      console.error("Service unavailable");
+      throw new Error("Service unavailable");
+    }
+
+    const message = await response.text();
+    throw new Error(message || "Failed to load Poly search results");
+  }
+
+  const data = await response.json();
+  const rawMarkets: any[] = Array.isArray(data?.markets)
+    ? data.markets
+    : Array.isArray(data)
+    ? data
+    : Array.isArray(data?.data)
+    ? data.data
+    : [];
+
+  const markets = rawMarkets.map((market) => normalizeMarket(market));
+
+  return {
+    ...data,
+    markets,
+  };
+}
+
+export function usePolySearch(params: UsePolySearchParams) {
+  const globalKeywords = useGlobalFilters((state) => state.keywords);
+
+  const queryParams = useMemo(() => ({
+    q: params.q ?? globalKeywords.join(" "),
+    active: params.active ?? true,
+    limit: params.limit ?? 30,
+    category: params.category,
+    sort: params.sort ?? "volume24h",
+  }), [
+    globalKeywords,
+    params.active,
+    params.category,
+    params.limit,
+    params.q,
+    params.sort,
+  ]);
+
+  const enabled = Boolean(queryParams.q);
+
+  return useQuery({
+    queryKey: ["poly", "search", queryParams],
+    queryFn: ({ signal }) =>
+      fetchPolySearch(
+        {
+          q: queryParams.q,
+          active: queryParams.active,
+          limit: queryParams.limit,
+          category: queryParams.category,
+          sort: queryParams.sort,
+        },
+        fetch,
+        signal,
+      ),
+    enabled,
+    ...commonQueryOptions,
+  });
+}

--- a/src/hooks/usePolySearch.ts
+++ b/src/hooks/usePolySearch.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { useGlobalFilters } from "@/stores/useGlobalFilters";
-import type { PolyMarket } from "@/types";
+import type { PolyMarket, PolyMarketApi, PolySearchApiResponse } from "@/types";
 
 import { commonQueryOptions, createAbortSignal, normalizeMarket } from "./utils";
 
@@ -50,19 +50,22 @@ export async function fetchPolySearch(
     throw new Error(message || "Failed to load Poly search results");
   }
 
-  const data = await response.json();
-  const rawMarkets: any[] = Array.isArray(data?.markets)
-    ? data.markets
-    : Array.isArray(data)
+  const data = (await response.json()) as PolySearchApiResponse;
+  const rawMarkets: PolyMarketApi[] = Array.isArray(data)
     ? data
+    : Array.isArray(data?.markets)
+    ? data.markets ?? []
     : Array.isArray(data?.data)
-    ? data.data
+    ? data.data ?? []
     : [];
 
   const markets = rawMarkets.map((market) => normalizeMarket(market));
 
+  const extraFields: Record<string, unknown> =
+    data && !Array.isArray(data) ? (data as Record<string, unknown>) : {};
+
   return {
-    ...data,
+    ...extraFields,
     markets,
   };
 }

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -1,0 +1,84 @@
+import type { PolyMarket, PolyToken } from "@/types";
+
+export const commonQueryOptions = {
+  cacheTime: 10 * 60 * 1000,
+  staleTime: 2 * 60 * 1000,
+  refetchOnWindowFocus: false,
+  onError: (error: Error) => console.error("Query failed:", error.message),
+};
+
+export function createAbortSignal(parent?: AbortSignal): AbortSignal {
+  const controller = new AbortController();
+  if (parent) {
+    if (parent.aborted) {
+      controller.abort();
+    } else {
+      parent.addEventListener("abort", () => controller.abort(), { once: true });
+    }
+  }
+  return controller.signal;
+}
+
+export function normalizeGdeltDate(value: string | number | undefined | null): string {
+  if (value == null) {
+    return "";
+  }
+
+  const raw = typeof value === "number" ? String(value) : value;
+  if (/^\d{8}$/.test(raw)) {
+    const year = raw.slice(0, 4);
+    const month = raw.slice(4, 6);
+    const day = raw.slice(6, 8);
+    return `${year}-${month}-${day}`;
+  }
+
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  return date.toISOString().split("T")[0] ?? "";
+}
+
+export function normalizeTokens(tokens: any[] | undefined): PolyToken[] {
+  if (!Array.isArray(tokens)) {
+    return [];
+  }
+
+  return tokens
+    .filter((token) => token && typeof token === "object")
+    .map((token) => {
+      const rawPrice = token.price;
+      const price =
+        typeof rawPrice === "number"
+          ? rawPrice
+          : typeof rawPrice === "string" && rawPrice.trim() !== ""
+          ? Number(rawPrice)
+          : undefined;
+
+      return {
+        id: String(token.id ?? ""),
+        outcome: token.outcome === "NO" ? "NO" : "YES",
+        price: Number.isFinite(price) ? price : undefined,
+      };
+    });
+}
+
+export function normalizeMarket(market: any): PolyMarket {
+  const tokens = normalizeTokens(market?.tokens);
+  const yesToken = tokens.find((token) => token.outcome === "YES");
+  const noToken = tokens.find((token) => token.outcome === "NO");
+
+  return {
+    id: String(market?.id ?? ""),
+    title: String(market?.title ?? ""),
+    endDate: market?.endDate ? String(market.endDate) : null,
+    volume24h: Number(market?.volume24h ?? 0) || 0,
+    liquidity: Number(market?.liquidity ?? 0) || 0,
+    status: String(market?.status ?? "unknown"),
+    category: market?.category ? String(market.category) : undefined,
+    tokens,
+    priceYes: yesToken?.price,
+    priceNo: noToken?.price,
+  };
+}

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -1,4 +1,4 @@
-import type { PolyMarket, PolyToken } from "@/types";
+import type { PolyMarket, PolyMarketApi, PolyToken, PolyTokenApi } from "@/types";
 
 export const commonQueryOptions = {
   cacheTime: 10 * 60 * 1000,
@@ -40,13 +40,13 @@ export function normalizeGdeltDate(value: string | number | undefined | null): s
   return date.toISOString().split("T")[0] ?? "";
 }
 
-export function normalizeTokens(tokens: any[] | undefined): PolyToken[] {
+export function normalizeTokens(tokens?: PolyTokenApi[] | null): PolyToken[] {
   if (!Array.isArray(tokens)) {
     return [];
   }
 
   return tokens
-    .filter((token) => token && typeof token === "object")
+    .filter((token): token is PolyTokenApi => Boolean(token) && typeof token === "object")
     .map((token) => {
       const rawPrice = token.price;
       const price =
@@ -64,8 +64,8 @@ export function normalizeTokens(tokens: any[] | undefined): PolyToken[] {
     });
 }
 
-export function normalizeMarket(market: any): PolyMarket {
-  const tokens = normalizeTokens(market?.tokens);
+export function normalizeMarket(market?: PolyMarketApi | null): PolyMarket {
+  const tokens = normalizeTokens(market?.tokens ?? null);
   const yesToken = tokens.find((token) => token.outcome === "YES");
   const noToken = tokens.find((token) => token.outcome === "NO");
 

--- a/src/stores/useGdeltMode.ts
+++ b/src/stores/useGdeltMode.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { create } from "zustand";
+
+export type GdeltMode = "context" | "country" | "bilateral" | "bbva";
+
+export type ContextParams = {
+  includeInsights: boolean;
+  limit: number;
+};
+
+export type CountryParams = {
+  country: string;
+};
+
+export type BilateralParams = {
+  country1: string;
+  country2: string;
+};
+
+export type BbvaParams = {
+  actor1: string;
+  actor2: string;
+  includeTotal: boolean;
+  cameoCodes?: string;
+};
+
+type ModeParams = {
+  context: ContextParams;
+  country: CountryParams;
+  bilateral: BilateralParams;
+  bbva: BbvaParams;
+};
+
+type GdeltModeState = {
+  mode: GdeltMode;
+  params: Partial<ModeParams>;
+  setMode: <TMode extends GdeltMode>(mode: TMode, params: ModeParams[TMode]) => void;
+};
+
+const defaultState: GdeltModeState = {
+  mode: "context",
+  params: {
+    context: {
+      includeInsights: true,
+      limit: 500,
+    },
+  },
+  setMode: () => {
+    throw new Error("Store not initialized");
+  },
+};
+
+export const useGdeltMode = create<GdeltModeState>((set) => ({
+  ...defaultState,
+  setMode: (mode, params) => set({ mode, params: { [mode]: params } }),
+}));

--- a/src/stores/useSidePanel.ts
+++ b/src/stores/useSidePanel.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+type SidePanelMode = "event" | "market";
+
+interface SidePanelPayload {
+  id?: string;
+  json?: Record<string, unknown> | null;
+  title?: string;
+  url?: string;
+}
+
+interface SidePanelState {
+  isOpen: boolean;
+  mode: SidePanelMode;
+  payload?: SidePanelPayload;
+  openPanel: (mode: SidePanelMode, payload?: SidePanelPayload) => void;
+  closePanel: () => void;
+}
+
+export const useSidePanel = create<SidePanelState>((set) => ({
+  isOpen: false,
+  mode: "event",
+  payload: undefined,
+  openPanel: (mode, payload) => set({ isOpen: true, mode, payload }),
+  closePanel: () => set({ isOpen: false, payload: undefined }),
+}));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,53 @@
+export interface GdeltSeriesPoint {
+  date: string;
+  conflict_events?: number;
+  avg_sentiment?: number;
+  avg_impact?: number;
+  interaction_count?: number;
+  relative_coverage?: number;
+}
+
+export interface GdeltEvent {
+  SQLDATE: number | string;
+  SOURCEURL: string;
+  Actor1CountryCode?: string;
+  EventCode?: string;
+  AvgTone?: number;
+  /* add other GDELT fields */
+  [key: string]: unknown;
+}
+
+export interface GdeltInsights {
+  total_events?: number;
+  keyword_matches?: Record<string, number>;
+  sentiment_analysis?: {
+    avg_tone?: number;
+  };
+  /* add from context insights */
+  [key: string]: unknown;
+}
+
+export interface PolyToken {
+  id: string;
+  outcome: "YES" | "NO";
+  price?: number;
+}
+
+export interface PolyMarket {
+  id: string;
+  title: string;
+  endDate: string | null;
+  volume24h: number;
+  liquidity: number;
+  status: string;
+  category?: string;
+  tokens: PolyToken[];
+  priceYes?: number;
+  priceNo?: number;
+}
+
+export interface PolyTrade {
+  price: number;
+  size: number;
+  timestamp: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,9 +11,27 @@ export interface GdeltEvent {
   SQLDATE: number | string;
   SOURCEURL: string;
   Actor1CountryCode?: string;
+  Actor2CountryCode?: string;
   EventCode?: string;
   AvgTone?: number;
   /* add other GDELT fields */
+  [key: string]: unknown;
+}
+
+export interface GdeltContextApiItem extends GdeltEvent {
+  DayDate?: string | number;
+  conflict_events?: number;
+  avg_sentiment?: number;
+  avg_impact?: number;
+  interaction_count?: number;
+  relative_coverage?: number;
+}
+
+export interface GdeltContextApiResponse {
+  data?: GdeltContextApiItem[];
+  insights?: GdeltInsights;
+  status?: string;
+  message?: string;
   [key: string]: unknown;
 }
 
@@ -33,6 +51,13 @@ export interface PolyToken {
   price?: number;
 }
 
+export interface PolyTokenApi {
+  id?: string | number | null;
+  outcome?: string | null;
+  price?: number | string | null;
+  [key: string]: unknown;
+}
+
 export interface PolyMarket {
   id: string;
   title: string;
@@ -45,6 +70,26 @@ export interface PolyMarket {
   priceYes?: number;
   priceNo?: number;
 }
+
+export interface PolyMarketApi {
+  id?: string | number | null;
+  title?: string | null;
+  endDate?: string | null;
+  volume24h?: number | string | null;
+  liquidity?: number | string | null;
+  status?: string | null;
+  category?: string | null;
+  tokens?: PolyTokenApi[] | null;
+  [key: string]: unknown;
+}
+
+export type PolySearchApiResponse =
+  | PolyMarketApi[]
+  | {
+      markets?: PolyMarketApi[] | null;
+      data?: PolyMarketApi[] | null;
+      [key: string]: unknown;
+    };
 
 export interface PolyTrade {
   price: number;


### PR DESCRIPTION
## Summary
- add typed interfaces for GDELT and Poly market payloads plus shared normalization helpers
- implement React Query hooks for GDELT context/country/bilateral/BBVA and Poly search/market details with global filter defaults
- configure Jest and add unit tests covering date normalization, guard errors, price derivation, and service error logging

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68de2e0a27688328ab22609257589d07