### PR TITLE
Deduplicate country codes in GDELT events list

### DIFF
--- a/src/components/gdelt/GdeltEventsList.tsx
+++ b/src/components/gdelt/GdeltEventsList.tsx
@@ -85,10 +85,14 @@ export function GdeltEventsList({
       const isoDate = normalizeGdeltDate(event.SQLDATE);
       const { hostname, path } = getHostnameAndPath(String(event.SOURCEURL ?? ""));
       const tone = typeof event.AvgTone === "number" ? event.AvgTone : undefined;
-      const countryCodes = [
-        typeof event.Actor1CountryCode === "string" ? event.Actor1CountryCode : undefined,
-        typeof event.Actor2CountryCode === "string" ? event.Actor2CountryCode : undefined,
-      ].filter((code): code is string => Boolean(code));
+      const countryCodes = Array.from(
+        new Set(
+          [
+            typeof event.Actor1CountryCode === "string" ? event.Actor1CountryCode : undefined,
+            typeof event.Actor2CountryCode === "string" ? event.Actor2CountryCode : undefined,
+          ].filter((code): code is string => Boolean(code)),
+        ),
+      );
 
       return {
         original: event,


### PR DESCRIPTION
## Summary
- deduplicate GDELT event country code arrays while normalizing events to avoid duplicate list keys during virtualization

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de6790ce508328bdf68692e90b8ce9