### PR TITLE
Allow Poly search without keywords

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -300,11 +300,11 @@ export default function HomePage() {
   const polyQuery = usePolySearch(
     datasets.poly
       ? {
-          q: keywords.join(" "),
+          q: keywords.length > 0 ? keywords.join(" ") : undefined,
           active: true,
           sort: "volume24h",
         }
-      : { q: "" },
+      : { enabled: false },
   );
 
   const activeGdeltState: QueryState = (() => {


### PR DESCRIPTION
## Summary
- allow the Polymarket search hook to accept an optional query string and avoid sending empty q parameters
- enable the Polymarket query when no keywords are provided so trending markets load by default
- update the home page to pass undefined for empty keyword lists and disable fetching when the dataset is hidden

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de7bc514c48328b320a799a09bea94