### PR TITLE
Deduplicate GDELT event country codes

### DIFF
--- a/src/components/gdelt/GdeltEventsList.tsx
+++ b/src/components/gdelt/GdeltEventsList.tsx
@@ -85,10 +85,14 @@ export function GdeltEventsList({
       const isoDate = normalizeGdeltDate(event.SQLDATE);
       const { hostname, path } = getHostnameAndPath(String(event.SOURCEURL ?? ""));
       const tone = typeof event.AvgTone === "number" ? event.AvgTone : undefined;
-      const countryCodes = [
-        typeof event.Actor1CountryCode === "string" ? event.Actor1CountryCode : undefined,
-        typeof event.Actor2CountryCode === "string" ? event.Actor2CountryCode : undefined,
-      ].filter((code): code is string => Boolean(code));
+      const countryCodes = Array.from(
+        new Set(
+          [
+            typeof event.Actor1CountryCode === "string" ? event.Actor1CountryCode : undefined,
+            typeof event.Actor2CountryCode === "string" ? event.Actor2CountryCode : undefined,
+          ].filter((code): code is string => Boolean(code)),
+        ),
+      );
 
       return {
         original: event,


### PR DESCRIPTION
## Summary
- deduplicate country codes when normalizing GDELT events to avoid duplicate keys during rendering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de7e1e2d788328bc780d7a29d0af92