### PR TITLE
Refine dashboard layout and theme styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,63 +2,134 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Poppins font configured via next/font/google in layout */
 :root {
-  --bg: #0b0b0c;
-  --surface: #16181c;
-  --surface-2: #1b1e24;
-  --primary: #e02424;
-  --primary-600: #c51d1d;
-  --accent: #f97316;
-  --success: #16a34a;
-  --text: #eaecee;
-  --muted: #a7adb7;
-  --border: #24272e;
-  --header-h: 72px;
-  --topbar-gap: 20px;
   color-scheme: dark;
-}
 
-@media (max-width: 1023px) {
-  :root {
-    --topbar-gap: 16px;
-  }
-}
+  /* Background layers */
+  --bg: #141414;
+  --panel: #1a1a1d;
+  --card: #1e1e22;
+  --elev-2: #222227;
 
-@media (max-width: 767px) {
-  :root {
-    --topbar-gap: 12px;
-  }
+  /* Text & borders */
+  --fg: #f2f3f5;
+  --muted: #a1a1aa;
+  --border: #2a2a2f;
+
+  /* Accents */
+  --accent: #e53935;
+  --accent-light: #ff6b6b;
+  --accent-dark: #d32f2f;
+
+  --violet: #7c4dff;
+  --violet-light: #b388ff;
+  --violet-dark: #5e35b1;
+
+  /* Glow */
+  --glow-red: rgba(229, 57, 53, 0.25);
+  --glow-violet: rgba(124, 77, 255, 0.22);
+
+  /* Gradients */
+  --grad-red: linear-gradient(180deg, #ff6b6b 0%, #e53935 70%, rgba(229, 57, 53, 0) 100%);
+  --grad-violet: linear-gradient(180deg, #b388ff 0%, #7c4dff 70%, rgba(124, 77, 255, 0) 100%);
 }
 
 @layer base {
   *,
   *::before,
   *::after {
-    @apply border-border;
+    border-color: var(--border);
   }
 
   body {
-    @apply min-h-screen bg-[var(--bg)] font-[family-name(poppins)] text-[var(--text)] antialiased;
+    min-height: 100vh;
+    background-color: var(--bg);
+    color: var(--fg);
+    @apply antialiased;
   }
-}
-
-.main-wrap {
-  padding-top: var(--topbar-gap);
-}
-
-.surface-pill {
-  @apply bg-gradient-to-b from-[var(--surface-2)] to-[var(--surface)] ring-inset ring-1 ring-white/5 shadow-md;
 }
 
 @layer components {
-  .h1 {
-    @apply text-2xl md:text-3xl font-bold tracking-tight;
+  .container-outer {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 1360px;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
   }
-}
 
-@layer utilities {
+  @screen lg {
+    .container-outer {
+      padding-left: 2rem;
+      padding-right: 2rem;
+    }
+  }
+
   .card {
-    @apply rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-[0_8px_30px_rgba(0,0,0,0.25)];
+    position: relative;
+    border-radius: 1rem;
+    border: 1px solid var(--border);
+    background: var(--card);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  }
+
+  .card-elev {
+    position: relative;
+    border-radius: 1rem;
+    border: 1px solid var(--border);
+    background: var(--card);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+  }
+
+  .card-elev::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(120% 120% at 0% 0%, var(--glow-violet), transparent 70%);
+    opacity: 0.4;
+    pointer-events: none;
+  }
+
+  .kpi {
+    font-size: 28px;
+    line-height: 34px;
+    font-weight: 700;
+    color: var(--fg);
+  }
+
+  .meta {
+    font-size: 12px;
+    color: var(--muted);
+  }
+
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 2rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+    border-radius: 9999px;
+    border: 1px solid var(--border);
+    background: rgba(255, 255, 255, 0.02);
+    font-size: 13px;
+  }
+
+  .pill-active {
+    background: var(--accent);
+    color: #000;
+    box-shadow: 0 0 0 6px var(--glow-red);
+  }
+
+  .iconbtn {
+    height: 2.25rem;
+    width: 2.25rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.75rem;
+    border: 1px solid var(--border);
+    background: rgba(255, 255, 255, 0.02);
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,39 +29,41 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="bg-bg">
+    <html lang="en">
       <body
         className={cn(
-          "min-h-screen bg-[var(--bg)] text-[var(--text)] antialiased",
+          "min-h-screen bg-[color:var(--bg)] text-[color:var(--fg)] antialiased",
           poppins.className,
         )}
       >
         <AppQueryProvider>
-          <div className="flex min-h-screen flex-col">
-            <header className="sticky top-0 z-50 border-b border-border/70 bg-surface/80 backdrop-blur">
-              <div className="mx-auto flex h-[72px] w-full max-w-none items-center justify-between px-5">
-                <span className="text-lg font-bold tracking-tight">Poly</span>
-                <nav className="flex items-center gap-6 text-sm text-muted">
-                  <Link className="transition hover:text-text" href="/">
+          <div className="flex min-h-screen flex-col bg-[color:var(--bg)]">
+            <header className="border-b border-[color:var(--border)]/80 bg-[color:var(--panel)]/80 backdrop-blur-lg">
+              <div className="container-outer flex h-16 items-center justify-between">
+                <span className="text-lg font-semibold tracking-tight">Poly</span>
+                <nav className="flex items-center gap-6 text-sm text-[color:var(--muted)]">
+                  <Link className="transition hover:text-[color:var(--fg)]" href="/">
                     Overview
                   </Link>
-                  <Link className="transition hover:text-text" href="/reports">
+                  <Link className="transition hover:text-[color:var(--fg)]" href="/reports">
                     Reports
                   </Link>
-                  <Link className="transition hover:text-text" href="/settings">
+                  <Link className="transition hover:text-[color:var(--fg)]" href="/settings">
                     Settings
                   </Link>
                 </nav>
               </div>
             </header>
             <TopBar />
-            <main className="main-wrap mx-auto w-full max-w-[1440px] flex-1 px-5 pb-10">
-              {children}
+            <main className="flex-1 overflow-hidden">
+              <div className="container-outer flex h-full flex-col overflow-hidden py-6">
+                {children}
+              </div>
             </main>
-            <footer className="border-t border-border/70 bg-surface/60">
-              <div className="mx-auto flex h-16 w-full max-w-none items-center justify-between px-5 text-xs text-muted">
+            <footer className="border-t border-[color:var(--border)]/80 bg-[color:var(--panel)]/60">
+              <div className="container-outer flex h-12 items-center justify-between text-xs text-[color:var(--muted)]">
                 <span>&copy; {new Date().getFullYear()} Poly UI</span>
-                <span>Built with Next.js 14 · Tailwind CSS · shadcn/ui</span>
+                <span>Next.js · Tailwind CSS · shadcn/ui</span>
               </div>
             </footer>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -206,8 +206,8 @@ const toIsoString = (timestamp?: number): string | undefined => {
 };
 
 const DisabledDatasetCard = ({ title, description }: { title: string; description: string }) => (
-  <div className="flex h-full min-h-[200px] flex-col items-center justify-center rounded-3xl border border-dashed border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/40 p-6 text-center">
-    <h3 className="text-base font-semibold text-[color:var(--text)]">{title}</h3>
+  <div className="card flex h-full min-h-[200px] flex-col items-center justify-center rounded-2xl border border-dashed border-[color:var(--border)]/70 bg-[color:var(--card)]/70 p-6 text-center">
+    <h3 className="text-base font-semibold text-[color:var(--fg)]">{title}</h3>
     <p className="mt-2 text-sm text-[color:var(--muted)]">{description}</p>
   </div>
 );
@@ -559,101 +559,115 @@ export default function HomePage() {
   );
 
   return (
-    <main className="space-y-6">
-      <div className="grid grid-cols-1 gap-5 md:grid-cols-8 lg:grid-cols-12">
-        <section className="md:col-span-5 lg:col-span-8">
-          {datasets.gdelt ? (
-            <GdeltChart
-              series={gdeltSeries}
-              aggregation={gdeltAggregation}
-              onDateClick={(iso) => setActiveDate(iso)}
-              isLoading={gdeltLoading}
-              error={gdeltError}
-            />
-          ) : (
-            <DisabledDatasetCard
-              title="GDELT dataset disabled"
-              description="Enable the GDELT dataset from the filters to explore temporal activity."
-            />
-          )}
-        </section>
+    <div className="flex min-h-0 flex-1 flex-col gap-6">
+      <div className="grid flex-1 min-h-0 grid-cols-1 gap-6 lg:grid-cols-[minmax(0,7fr)_minmax(0,5fr)] xl:grid-cols-[minmax(0,8fr)_minmax(0,5fr)]">
+        <div className="grid min-h-0 grid-rows-[minmax(0,3fr)_minmax(0,2fr)] gap-6">
+          <section className="flex min-h-0 flex-col">
+            {datasets.gdelt ? (
+              <GdeltChart
+                series={gdeltSeries}
+                aggregation={gdeltAggregation}
+                onDateClick={(iso) => setActiveDate(iso)}
+                isLoading={gdeltLoading}
+                error={gdeltError}
+              />
+            ) : (
+              <DisabledDatasetCard
+                title="GDELT dataset disabled"
+                description="Enable the GDELT dataset from the filters to explore temporal activity."
+              />
+            )}
+          </section>
 
-        <section className="md:col-span-3 lg:col-span-4">
-          {datasets.gdelt ? (
-            <KpiCards
-              totalEvents={kpiValues.totalEvents}
-              avgTone={kpiValues.avgTone}
-              avgImpact={kpiValues.avgImpact}
-              topPair={kpiValues.topPair ?? undefined}
-              isLoading={gdeltLoading}
-              error={gdeltError}
-            />
-          ) : (
-            <DisabledDatasetCard
-              title="KPIs unavailable"
-              description="Turn on the GDELT feed to surface sentiment and impact metrics."
-            />
-          )}
-        </section>
+          <section className="flex min-h-0 flex-col">
+            {datasets.gdelt ? (
+              <GdeltEventsList
+                events={gdeltEvents}
+                activeDate={activeDate ?? undefined}
+                onOpen={(event) =>
+                  openPanel("event", {
+                    json: event,
+                    title: typeof event.SOURCEURL === "string" ? event.SOURCEURL : "Event details",
+                    url: typeof event.SOURCEURL === "string" ? event.SOURCEURL : undefined,
+                  })
+                }
+                isLoading={gdeltLoading}
+                error={gdeltError}
+              />
+            ) : (
+              <DisabledDatasetCard
+                title="Events hidden"
+                description="Activate the GDELT stream to review the underlying source events."
+              />
+            )}
+          </section>
+        </div>
 
-        <section className="md:col-span-5 lg:col-span-8">
-          {datasets.gdelt ? (
-            <GdeltEventsList
-              events={gdeltEvents}
-              activeDate={activeDate ?? undefined}
-              onOpen={(event) =>
-                openPanel("event", {
-                  json: event,
-                  title: typeof event.SOURCEURL === "string" ? event.SOURCEURL : "Event details",
-                  url: typeof event.SOURCEURL === "string" ? event.SOURCEURL : undefined,
-                })
-              }
-              isLoading={gdeltLoading}
-              error={gdeltError}
-            />
-          ) : (
-            <DisabledDatasetCard
-              title="Events hidden"
-              description="Activate the GDELT stream to review the underlying source events."
-            />
-          )}
-        </section>
+        <div className="flex min-h-0 flex-col gap-6">
+          <div>
+            {datasets.gdelt ? (
+              <KpiCards
+                totalEvents={kpiValues.totalEvents}
+                avgTone={kpiValues.avgTone}
+                avgImpact={kpiValues.avgImpact}
+                topPair={kpiValues.topPair ?? undefined}
+                isLoading={gdeltLoading}
+                error={gdeltError}
+              />
+            ) : (
+              <DisabledDatasetCard
+                title="KPIs unavailable"
+                description="Turn on the GDELT feed to surface sentiment and impact metrics."
+              />
+            )}
+          </div>
 
-        <section className="md:col-span-3 lg:col-span-4">
-          {datasets.poly ? (
-            <PolyMarketGrid
-              markets={markets}
-              onOpen={(id) => openPanel("market", { id })}
-              isLoading={polyLoading}
-              error={polyError}
-            />
-          ) : (
-            <DisabledDatasetCard
-              title="Polymarket disabled"
-              description="Enable the Polymarket dataset to browse high-liquidity markets."
-            />
-          )}
-        </section>
+          <div className="grid flex-1 min-h-0 grid-cols-1 gap-6 xl:grid-cols-2">
+            <div className="min-h-0">
+              {datasets.gdelt ? (
+                <InsightsPanel insights={gdeltInsights} isLoading={gdeltLoading} error={gdeltError} />
+              ) : (
+                <DisabledDatasetCard
+                  title="Insights paused"
+                  description="Switch the GDELT dataset back on to surface keyword and actor insights."
+                />
+              )}
+            </div>
 
-        <section className="md:col-span-3 lg:col-span-5">
-          <TwitterPlaceholder comingSoon={comingSoon} />
-        </section>
+            <div className="min-h-0">
+              <ActivityPanel datasets={datasetStatuses} recentQueries={recentQueries} />
+            </div>
 
-        <section className="md:col-span-3 lg:col-span-4">
-          {datasets.gdelt ? (
-            <InsightsPanel insights={gdeltInsights} isLoading={gdeltLoading} error={gdeltError} />
-          ) : (
-            <DisabledDatasetCard
-              title="Insights paused"
-              description="Switch the GDELT dataset back on to surface keyword and actor insights."
-            />
-          )}
-        </section>
+            <div className="xl:col-span-2 flex min-h-0 flex-col">
+              {datasets.poly ? (
+                <div className="card flex min-h-0 flex-col gap-5 rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--card)]/90 p-5">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-base font-semibold text-[color:var(--fg)]">Polymarket highlights</h3>
+                    <span className="meta uppercase tracking-[0.2em]">Top markets</span>
+                  </div>
+                  <div className="min-h-0 overflow-y-auto pr-1">
+                    <PolyMarketGrid
+                      markets={markets}
+                      onOpen={(id) => openPanel("market", { id })}
+                      isLoading={polyLoading}
+                      error={polyError}
+                    />
+                  </div>
+                </div>
+              ) : (
+                <DisabledDatasetCard
+                  title="Polymarket disabled"
+                  description="Enable the Polymarket dataset to browse high-liquidity markets."
+                />
+              )}
+            </div>
 
-        <section className="md:col-span-2 lg:col-span-3">
-          <ActivityPanel datasets={datasetStatuses} recentQueries={recentQueries} />
-        </section>
+            <div className="xl:col-span-2 min-h-0">
+              <TwitterPlaceholder comingSoon={comingSoon} />
+            </div>
+          </div>
+        </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -59,11 +59,11 @@ export default function TopBar() {
   }, [triggerRefetch]);
 
   return (
-    <div className="sticky top-[var(--header-h)] z-40 border-b border-[color:var(--border)]/60 bg-[color:var(--surface)]/85 backdrop-blur-md shadow-[0_10px_30px_rgba(0,0,0,0.35)]">
+    <div className="sticky top-16 z-40 border-b border-[color:var(--border)]/70 bg-[color:var(--panel)]/80 backdrop-blur-xl">
       <div className="relative">
-        <div className="absolute inset-x-0 -bottom-px h-px bg-gradient-to-r from-[color:var(--primary)]/35 via-transparent to-[color:var(--primary)]/35" />
-        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(120%_60%_at_50%_-10%,rgba(224,36,36,0.15),transparent_60%)]" />
-        <div className="relative mx-auto max-w-[1440px] px-5 py-4">
+        <div className="absolute inset-x-0 -bottom-px h-px bg-gradient-to-r from-[color:var(--accent)]/50 via-transparent to-[color:var(--accent)]/50" />
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(120%_60%_at_50%_-10%,var(--glow-red),transparent_60%)]" />
+        <div className="relative container-outer py-4">
           <SearchBar
             loading={activeFetches > 0}
             error={null}

--- a/src/components/gdelt/GdeltChart.tsx
+++ b/src/components/gdelt/GdeltChart.tsx
@@ -1,6 +1,6 @@
-"use client"
+"use client";
 
-import { useMemo, useState } from "react"
+import { useMemo, useState } from "react";
 import {
   Area,
   AreaChart,
@@ -11,56 +11,56 @@ import {
   Tooltip,
   XAxis,
   YAxis,
-} from "recharts"
+} from "recharts";
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import type { GdeltSeriesPoint } from "@/types"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { GdeltSeriesPoint } from "@/types";
 
 interface GdeltChartProps {
-  series: GdeltSeriesPoint[]
-  aggregation?: "daily" | "monthly"
-  onDateClick?: (iso: string) => void
-  isLoading?: boolean
-  error?: string | null
+  series: GdeltSeriesPoint[];
+  aggregation?: "daily" | "monthly";
+  onDateClick?: (iso: string) => void;
+  isLoading?: boolean;
+  error?: string | null;
 }
 
 const METRIC_CONFIG = {
   conflict_events: {
     label: "Events",
-    color: "#f87171",
+    color: "#FF6B6B",
     chart: "line" as const,
   },
   avg_sentiment: {
     label: "Sentiment",
-    color: "#f43f5e",
+    color: "#E53935",
     chart: "area" as const,
   },
   avg_impact: {
     label: "Impact",
-    color: "#ef4444",
+    color: "#FF6B6B",
     chart: "line" as const,
   },
   relative_coverage: {
     label: "Rel Coverage",
-    color: "#dc2626",
+    color: "#7C4DFF",
     chart: "line" as const,
   },
-}
+};
 
-type MetricKey = keyof typeof METRIC_CONFIG
+type MetricKey = keyof typeof METRIC_CONFIG;
 
 const tooltipFormatter = (value?: number | string) => {
   if (value === null || value === undefined || value === "") {
-    return "–"
+    return "–";
   }
   if (typeof value === "number") {
     if (Math.abs(value) >= 1000) {
-      return value.toLocaleString(undefined, { maximumFractionDigits: 0 })
+      return value.toLocaleString(undefined, { maximumFractionDigits: 0 });
     }
-    return value.toLocaleString(undefined, { maximumFractionDigits: 2 })
+    return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
   }
-  return value
-}
+  return value;
+};
 
 export function GdeltChart({
   series,
@@ -69,7 +69,7 @@ export function GdeltChart({
   isLoading = false,
   error,
 }: GdeltChartProps) {
-  const [metric, setMetric] = useState<MetricKey>("conflict_events")
+  const [metric, setMetric] = useState<MetricKey>("conflict_events");
 
   const preparedSeries = useMemo(() => {
     return series.map((point) => ({
@@ -78,62 +78,61 @@ export function GdeltChart({
       avg_sentiment: point.avg_sentiment ?? 0,
       avg_impact: point.avg_impact ?? 0,
       relative_coverage: point.relative_coverage ?? 0,
-    }))
-  }, [series])
+    }));
+  }, [series]);
 
-  const selectedMetric = METRIC_CONFIG[metric]
-  const hasData = preparedSeries.length > 0
+  const selectedMetric = METRIC_CONFIG[metric];
+  const hasData = preparedSeries.length > 0;
 
   if (isLoading) {
     return (
-      <div className="relative h-[380px] overflow-hidden rounded-3xl bg-gradient-to-br from-[var(--surface)] to-[var(--surface-2)] p-4">
-        {aggregation === "monthly" && (
-          <span className="absolute right-4 top-3 rounded-full bg-[var(--primary)]/20 px-2 py-1 text-xs font-medium text-[var(--primary)]">
-            Monthly aggregation
-          </span>
-        )}
-        <div className="flex h-full w-full flex-col gap-4">
-          <div className="h-8 w-48 animate-pulse rounded-full bg-gradient-to-r from-[var(--surface-2)] to-[var(--surface-3)]" />
-          <div className="flex-1 animate-pulse rounded-3xl bg-gradient-to-br from-[var(--surface-2)] via-[var(--surface-3)] to-[var(--surface-2)]" />
+      <div className="card-elev flex h-full min-h-[320px] flex-col overflow-hidden p-6">
+        <div className="flex flex-1 flex-col gap-4">
+          <div className="h-8 w-40 animate-pulse rounded-full bg-[color:var(--elev-2)]/70" />
+          <div className="flex-1 animate-pulse rounded-2xl bg-[color:var(--elev-2)]/60" />
         </div>
       </div>
-    )
+    );
   }
 
   if (error) {
     return (
-      <div className="relative h-[380px] rounded-3xl border border-red-400/40 bg-red-500/10 p-4 text-red-200">
-        <p className="text-sm font-medium">Unable to load GDELT data</p>
-        <p className="mt-2 text-xs opacity-80">{error}</p>
+      <div className="card flex h-full min-h-[320px] flex-col justify-center gap-2 rounded-2xl border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/10 p-6 text-sm text-[color:var(--accent-light)]">
+        <p className="font-medium">Unable to load GDELT data</p>
+        <p className="text-xs opacity-80">{error}</p>
       </div>
-    )
+    );
   }
 
   if (!hasData) {
     return (
-      <div className="relative flex h-[380px] flex-col items-center justify-center rounded-3xl bg-gradient-to-br from-[var(--surface)] to-[var(--surface-2)] p-4 text-sm text-muted-foreground">
+      <div className="card flex h-full min-h-[320px] flex-col items-center justify-center rounded-2xl border border-dashed border-[color:var(--border)]/70 bg-[color:var(--card)]/70 p-6 text-sm text-[color:var(--muted)]">
         <p>No activity found for the selected filters.</p>
       </div>
-    )
+    );
   }
 
-  const ChartComponent = selectedMetric.chart === "area" ? AreaChart : LineChart
+  const ChartComponent = selectedMetric.chart === "area" ? AreaChart : LineChart;
 
   return (
-    <div className="relative h-[380px] rounded-3xl bg-gradient-to-br from-[var(--surface)] to-[var(--surface-2)] p-4 shadow-lg shadow-black/5">
+    <div className="card-elev flex h-full min-h-[320px] flex-col overflow-hidden p-6">
       {aggregation === "monthly" && (
-        <span className="absolute right-4 top-3 rounded-full bg-[var(--primary)]/20 px-2 py-1 text-xs font-medium text-[var(--primary)]">
+        <span className="pill pointer-events-none self-end bg-[color:var(--accent)]/15 text-[color:var(--accent-light)]">
           Monthly aggregation
         </span>
       )}
       <Tabs
         value={metric}
         onValueChange={(value) => setMetric(value as MetricKey)}
-        className="flex h-full flex-col"
+        className="mt-4 flex h-full flex-col"
       >
-        <TabsList className="w-max bg-[var(--surface-2)]/70 backdrop-blur">
+        <TabsList className="w-max rounded-full bg-[color:var(--panel)]/80 p-1">
           {(Object.entries(METRIC_CONFIG) as [MetricKey, (typeof METRIC_CONFIG)[MetricKey]][]).map(([key, config]) => (
-            <TabsTrigger key={key} value={key} className="min-w-[96px]">
+            <TabsTrigger
+              key={key}
+              value={key}
+              className="rounded-full px-4 py-1 text-sm data-[state=active]:bg-[color:var(--accent)] data-[state=active]:text-black"
+            >
               {config.label}
             </TabsTrigger>
           ))}
@@ -144,9 +143,9 @@ export function GdeltChart({
               data={preparedSeries}
               margin={{ top: 16, right: 24, left: 0, bottom: 16 }}
               onClick={(state) => {
-                const payload = state?.activePayload?.[0]?.payload as GdeltSeriesPoint | undefined
+                const payload = state?.activePayload?.[0]?.payload as GdeltSeriesPoint | undefined;
                 if (payload?.date && onDateClick) {
-                  onDateClick(payload.date)
+                  onDateClick(payload.date);
                 }
               }}
             >
@@ -156,9 +155,9 @@ export function GdeltChart({
                   <stop offset="95%" stopColor={selectedMetric.color} stopOpacity={0.05} />
                 </linearGradient>
               </defs>
-              <XAxis dataKey="date" tick={{ fill: "var(--muted-foreground)" }} tickLine={false} axisLine={false} minTickGap={24} />
+              <XAxis dataKey="date" tick={{ fill: "var(--muted)", fontSize: 12 }} tickLine={false} axisLine={false} minTickGap={24} />
               <YAxis
-                tick={{ fill: "var(--muted-foreground)" }}
+                tick={{ fill: "var(--muted)", fontSize: 12 }}
                 tickLine={false}
                 axisLine={false}
                 width={60}
@@ -166,11 +165,22 @@ export function GdeltChart({
               />
               <Tooltip
                 wrapperClassName="!bg-transparent"
-                contentStyle={{ borderRadius: 16, border: "none", boxShadow: "0 10px 30px rgba(0,0,0,0.25)", background: "var(--surface)" }}
-                labelStyle={{ fontWeight: 600, color: "var(--foreground)" }}
+                contentStyle={{
+                  borderRadius: 16,
+                  border: "1px solid rgba(255,255,255,0.05)",
+                  boxShadow: "0 20px 50px rgba(0,0,0,0.45)",
+                  background: "var(--panel)",
+                }}
+                labelStyle={{ fontWeight: 600, color: "var(--fg)" }}
                 formatter={(value) => [tooltipFormatter(value) as string, selectedMetric.label]}
               />
-              <Brush dataKey="date" height={24} stroke={selectedMetric.color} travellerWidth={12} />
+              <Brush
+                dataKey="date"
+                height={24}
+                stroke={selectedMetric.color}
+                travellerWidth={12}
+                fill="rgba(255,255,255,0.02)"
+              />
               {selectedMetric.chart === "area" ? (
                 <Area
                   type="monotone"
@@ -186,7 +196,7 @@ export function GdeltChart({
                   dataKey={metric}
                   stroke={selectedMetric.color}
                   strokeWidth={3}
-                  dot={{ r: 2, strokeWidth: 1, stroke: selectedMetric.color, fill: "var(--surface)" }}
+                  dot={{ r: 2, strokeWidth: 1, stroke: selectedMetric.color, fill: "var(--card)" }}
                   activeDot={{ r: 4 }}
                 />
               )}
@@ -195,5 +205,5 @@ export function GdeltChart({
         </TabsContent>
       </Tabs>
     </div>
-  )
+  );
 }

--- a/src/components/gdelt/GdeltEventsList.tsx
+++ b/src/components/gdelt/GdeltEventsList.tsx
@@ -110,23 +110,21 @@ export function GdeltEventsList({
   const rowVirtualizer = useVirtualizer({
     count: normalizedEvents.length,
     getScrollElement: () => containerRef.current,
-    estimateSize: () => 88,
+    estimateSize: () => 92,
     overscan: 12,
   });
 
   if (isLoading) {
     return (
-      <div className="relative h-[400px] rounded-3xl bg-gradient-to-br from-[color:var(--surface)] to-[color:var(--surface-2)] p-4">
-        <div className="flex flex-col gap-4">
-          <div className="h-6 w-40 animate-pulse rounded-full bg-gradient-to-r from-[color:var(--surface-2)] to-[color:var(--surface-3)]" />
-          <div className="space-y-3">
-            {Array.from({ length: 6 }).map((_, index) => (
-              <div
-                key={index}
-                className="h-16 animate-pulse rounded-2xl bg-gradient-to-r from-[color:var(--surface-2)] via-[color:var(--surface-3)] to-[color:var(--surface-2)]"
-              />
-            ))}
-          </div>
+      <div className="card flex h-full min-h-[320px] flex-col gap-4 rounded-2xl bg-[color:var(--card)]/70 p-6">
+        <div className="h-6 w-48 animate-pulse rounded-full bg-[color:var(--elev-2)]/70" />
+        <div className="space-y-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-16 animate-pulse rounded-2xl bg-[color:var(--elev-2)]/60"
+            />
+          ))}
         </div>
       </div>
     );
@@ -134,34 +132,31 @@ export function GdeltEventsList({
 
   if (error) {
     return (
-      <div className="relative h-[400px] rounded-3xl border border-red-400/40 bg-red-500/10 p-4 text-red-200">
-        <p className="text-sm font-medium">Unable to load GDELT events</p>
-        <p className="mt-2 text-xs opacity-80">{error}</p>
+      <div className="card flex h-full min-h-[320px] flex-col justify-center gap-2 rounded-2xl border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/10 p-6 text-sm text-[color:var(--accent-light)]">
+        <p className="font-medium">Unable to load GDELT events</p>
+        <p className="text-xs opacity-80">{error}</p>
       </div>
     );
   }
 
   if (normalizedEvents.length === 0) {
     return (
-      <div className="relative flex h-[400px] flex-col items-center justify-center rounded-3xl bg-gradient-to-br from-[color:var(--surface)] to-[color:var(--surface-2)] p-4 text-sm text-[color:var(--muted)]">
+      <div className="card flex h-full min-h-[320px] flex-col items-center justify-center rounded-2xl border border-dashed border-[color:var(--border)]/70 bg-[color:var(--card)]/70 p-6 text-sm text-[color:var(--muted)]">
         <p>No GDELT events found for the selected period.</p>
       </div>
     );
   }
 
   return (
-    <div className="relative h-[400px] overflow-hidden rounded-3xl bg-gradient-to-br from-[color:var(--surface)] to-[color:var(--surface-2)] p-4 shadow-lg shadow-black/5">
-      <div className="flex items-center justify-between">
+    <div className="card flex h-full min-h-[320px] flex-col overflow-hidden rounded-2xl bg-[color:var(--card)]/90">
+      <div className="flex items-center justify-between border-b border-[color:var(--border)]/60 px-6 py-5">
         <div>
-          <h3 className="text-base font-semibold text-[color:var(--text)]">Event stream</h3>
-          <p className="text-xs text-[color:var(--muted)]">Live slice of the latest {normalizedEvents.length.toLocaleString()} articles.</p>
+          <h3 className="text-base font-semibold text-[color:var(--fg)]">Event stream</h3>
+          <p className="meta mt-1">Live slice of the latest {normalizedEvents.length.toLocaleString()} articles.</p>
         </div>
       </div>
 
-      <div
-        ref={containerRef}
-        className="mt-4 h-[320px] overflow-y-auto pr-2"
-      >
+      <div ref={containerRef} className="flex-1 overflow-y-auto px-3 pb-6 pt-4">
         <div
           style={{
             height: `${rowVirtualizer.getTotalSize()}px`,
@@ -177,7 +172,7 @@ export function GdeltEventsList({
               <div
                 key={event.id}
                 data-index={virtualRow.index}
-                className="absolute left-0 right-0 px-1"
+                className="absolute left-0 right-0 px-3"
                 style={{
                   transform: `translateY(${virtualRow.start}px)`,
                   height: `${virtualRow.size}px`,
@@ -194,31 +189,31 @@ export function GdeltEventsList({
                     }
                   }}
                   className={clsx(
-                    "group flex h-full cursor-pointer flex-col justify-center rounded-2xl border border-transparent bg-[color:var(--surface-2)]/40 px-4 py-3 shadow-sm shadow-black/5 transition",
-                    isActive && "border-[color:var(--primary)]/60 bg-[color:var(--primary)]/10",
-                    !isActive && "hover:border-[color:var(--primary)]/40 hover:bg-[color:var(--surface-2)]/70",
+                    "group flex h-full cursor-pointer flex-col justify-center rounded-2xl border border-transparent bg-[color:var(--panel)]/40 px-4 py-3 transition",
+                    isActive && "border-[color:var(--accent)]/60 bg-[color:var(--accent)]/15",
+                    !isActive && "hover:border-[color:var(--accent)]/40 hover:bg-[color:var(--panel)]/60",
                   )}
                 >
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="min-w-0 flex-1">
-                      <p className="text-sm font-semibold text-[color:var(--text)]">
+                      <p className="text-sm font-semibold text-[color:var(--fg)]">
                         {event.hostname || "Unknown source"}
                       </p>
                       {event.path && (
                         <p className="truncate text-xs text-[color:var(--muted)]">{truncate(event.path)}</p>
                       )}
                       {event.isoDate && (
-                        <p className="mt-1 text-xs uppercase tracking-wide text-[color:var(--muted)]">{event.isoDate}</p>
+                        <p className="meta mt-1 uppercase tracking-[0.2em]">{event.isoDate}</p>
                       )}
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
                       {event.eventCode && (
                         <span
                           className={clsx(
-                            "rounded-full border px-2 py-0.5 text-xs font-medium",
+                            "pill border px-2 py-0 text-xs font-medium",
                             negative
-                              ? "border-red-500/40 bg-red-500/15 text-red-200"
-                              : "border-[color:var(--primary)]/40 bg-[color:var(--primary)]/15 text-[color:var(--primary)]",
+                              ? "border-[color:var(--accent)]/40 bg-[color:var(--accent)]/15 text-[color:var(--accent-light)]"
+                              : "border-emerald-400/40 bg-emerald-500/10 text-emerald-200",
                           )}
                         >
                           Code {event.eventCode}
@@ -227,12 +222,12 @@ export function GdeltEventsList({
                       {event.tone != null && (
                         <span
                           className={clsx(
-                            "rounded-full border px-2 py-0.5 text-xs font-semibold",
+                            "pill px-2 py-0 text-xs font-semibold",
                             event.tone > 1
-                              ? "border-emerald-400/40 bg-emerald-500/15 text-emerald-200"
+                              ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-200"
                               : event.tone < -1
-                              ? "border-red-500/40 bg-red-500/15 text-red-200"
-                              : "border-[color:var(--border)]/60 bg-[color:var(--surface-3)]/40 text-[color:var(--text)]",
+                              ? "border-[color:var(--accent)]/40 bg-[color:var(--accent)]/15 text-[color:var(--accent-light)]"
+                              : "border-[color:var(--border)]/60 bg-[color:var(--panel)]/50 text-[color:var(--fg)]/90",
                           )}
                         >
                           Tone {toneLabel(event.tone)}
@@ -243,7 +238,7 @@ export function GdeltEventsList({
                           {event.countryCodes.map((code) => (
                             <span
                               key={`${event.id}-${code}`}
-                              className="flex items-center gap-1 rounded-full border border-[color:var(--border)]/60 bg-[color:var(--surface-3)]/40 px-2 py-0.5 text-xs text-[color:var(--text)]"
+                              className="pill gap-1 border-[color:var(--border)]/60 bg-[color:var(--panel)]/50 text-xs text-[color:var(--fg)]/80"
                             >
                               <Flag className="h-3 w-3 opacity-60" aria-hidden="true" />
                               {code}
@@ -256,7 +251,7 @@ export function GdeltEventsList({
                           href={event.original.SOURCEURL}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-white/10 bg-white/5 text-[color:var(--text)] transition hover:border-[color:var(--primary)]/50 hover:bg-[color:var(--primary)]/20"
+                          className="iconbtn text-[color:var(--fg)] transition hover:border-[color:var(--accent)]/60 hover:bg-[color:var(--accent)]/20"
                           onClick={(clickEvent) => clickEvent.stopPropagation()}
                         >
                           <ExternalLink className="h-4 w-4" aria-hidden="true" />

--- a/src/components/gdelt/InsightsPanel.tsx
+++ b/src/components/gdelt/InsightsPanel.tsx
@@ -1,6 +1,6 @@
-"use client"
+"use client";
 
-import { useMemo } from "react"
+import { useMemo } from "react";
 import {
   Bar,
   BarChart,
@@ -8,62 +8,62 @@ import {
   Tooltip,
   XAxis,
   YAxis,
-} from "recharts"
+} from "recharts";
 
-import type { GdeltInsights } from "@/types"
+import type { GdeltInsights } from "@/types";
 
 interface InsightsPanelProps {
-  insights?: GdeltInsights | null
-  isLoading?: boolean
-  error?: string | null
+  insights?: GdeltInsights | null;
+  isLoading?: boolean;
+  error?: string | null;
 }
 
 interface KeywordEntry {
-  keyword: string
-  count: number
+  keyword: string;
+  count: number;
 }
 
 interface TemporalEntry {
-  label: string
-  value: number
+  label: string;
+  value: number;
 }
 
 interface ActorEntry {
-  name: string
-  count?: number
+  name: string;
+  count?: number;
 }
 
 const toKeywordEntries = (matches?: Record<string, number>): KeywordEntry[] => {
-  if (!matches) return []
+  if (!matches) return [];
 
   return Object.entries(matches)
     .map(([keyword, count]) => ({ keyword, count }))
     .filter((entry) => Number.isFinite(entry.count))
     .sort((a, b) => b.count - a.count)
-    .slice(0, 5)
-}
+    .slice(0, 5);
+};
 
 const toTemporalEntries = (insights?: GdeltInsights): TemporalEntry[] => {
-  const raw = (insights?.temporal_distribution ?? insights?.timeline ?? []) as unknown[]
+  const raw = (insights?.temporal_distribution ?? insights?.timeline ?? []) as unknown[];
 
   return raw
     .map((item) => {
       if (typeof item === "object" && item !== null) {
-        const record = item as Record<string, unknown>
-        const label = typeof record.date === "string" ? record.date : typeof record.label === "string" ? record.label : null
-        const valueCandidate = record.count ?? record.value ?? record.total
-        const value = typeof valueCandidate === "number" ? valueCandidate : Number(valueCandidate)
+        const record = item as Record<string, unknown>;
+        const label = typeof record.date === "string" ? record.date : typeof record.label === "string" ? record.label : null;
+        const valueCandidate = record.count ?? record.value ?? record.total;
+        const value = typeof valueCandidate === "number" ? valueCandidate : Number(valueCandidate);
         if (label && Number.isFinite(value)) {
-          return { label, value }
+          return { label, value };
         }
       }
-      return null
+      return null;
     })
-    .filter((entry): entry is TemporalEntry => Boolean(entry))
-}
+    .filter((entry): entry is TemporalEntry => Boolean(entry));
+};
 
 const toActorEntries = (insights?: GdeltInsights): ActorEntry[] => {
-  const { top_actors, actor_counts } = (insights ?? {}) as Record<string, unknown>
+  const { top_actors, actor_counts } = (insights ?? {}) as Record<string, unknown>;
 
   const raw = Array.isArray(top_actors)
     ? top_actors
@@ -73,15 +73,15 @@ const toActorEntries = (insights?: GdeltInsights): ActorEntry[] => {
         ? Object.entries(top_actors as Record<string, number>).map(([name, count]) => ({ name, count }))
         : typeof actor_counts === "object" && actor_counts !== null
           ? Object.entries(actor_counts as Record<string, number>).map(([name, count]) => ({ name, count }))
-          : []
+          : [];
 
   return (raw as unknown[])
     .map((item) => {
       if (typeof item === "string") {
-        return { name: item }
+        return { name: item };
       }
       if (typeof item === "object" && item !== null) {
-        const record = item as Record<string, unknown>
+        const record = item as Record<string, unknown>;
         const name =
           typeof record.name === "string"
             ? record.name
@@ -89,88 +89,91 @@ const toActorEntries = (insights?: GdeltInsights): ActorEntry[] => {
               ? record.actor
               : typeof record.label === "string"
                 ? record.label
-                : null
-        const countCandidate = record.count ?? record.value ?? record.total
-        const count = typeof countCandidate === "number" ? countCandidate : Number(countCandidate)
+                : null;
+        const countCandidate = record.count ?? record.value ?? record.total;
+        const count = typeof countCandidate === "number" ? countCandidate : Number(countCandidate);
         if (name) {
-          return { name, count: Number.isFinite(count) ? count : undefined }
+          return { name, count: Number.isFinite(count) ? count : undefined };
         }
       }
-      return null
+      return null;
     })
     .filter((entry): entry is ActorEntry => Boolean(entry))
-    .slice(0, 6)
-}
+    .slice(0, 6);
+};
 
 const toSpikeLabels = (insights?: GdeltInsights): string[] => {
-  const raw = (insights?.spikes ?? []) as unknown[]
+  const raw = (insights?.spikes ?? []) as unknown[];
   return raw
     .map((item) => {
-      if (typeof item === "string") return item
+      if (typeof item === "string") return item;
       if (typeof item === "object" && item !== null) {
-        const record = item as Record<string, unknown>
-        if (typeof record.label === "string") return record.label
-        if (typeof record.date === "string") return record.date
+        const record = item as Record<string, unknown>;
+        if (typeof record.label === "string") return record.label;
+        if (typeof record.date === "string") return record.date;
       }
-      return null
+      return null;
     })
     .filter((label): label is string => Boolean(label))
-    .slice(0, 3)
-}
+    .slice(0, 3);
+};
 
 export function InsightsPanel({ insights, isLoading = false, error }: InsightsPanelProps) {
-  const keywords = useMemo(() => toKeywordEntries(insights?.keyword_matches), [insights?.keyword_matches])
-  const temporal = useMemo(() => toTemporalEntries(insights ?? undefined), [insights])
-  const actors = useMemo(() => toActorEntries(insights ?? undefined), [insights])
-  const spikes = useMemo(() => toSpikeLabels(insights ?? undefined), [insights])
+  const keywords = useMemo(() => toKeywordEntries(insights?.keyword_matches), [insights?.keyword_matches]);
+  const temporal = useMemo(() => toTemporalEntries(insights ?? undefined), [insights]);
+  const actors = useMemo(() => toActorEntries(insights ?? undefined), [insights]);
+  const spikes = useMemo(() => toSpikeLabels(insights ?? undefined), [insights]);
 
   if (error) {
     return (
-      <div className="card compact rounded-2xl border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-100">
+      <div className="card rounded-2xl border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/10 p-5 text-sm text-[color:var(--accent-light)]">
         {error}
       </div>
-    )
+    );
   }
 
   if (isLoading) {
     return (
-      <div className="card compact space-y-4 rounded-2xl bg-gradient-to-br from-[color:var(--surface-2)] via-[color:var(--surface-3)] to-[color:var(--surface-2)] p-4">
-        <div className="h-5 w-40 animate-pulse rounded-full bg-white/10" />
+      <div className="card space-y-4 rounded-2xl bg-[color:var(--card)]/70 p-5">
+        <div className="h-5 w-40 animate-pulse rounded-full bg-[color:var(--elev-2)]/70" />
         <div className="space-y-2">
           {Array.from({ length: 5 }).map((_, index) => (
-            <div key={index} className="h-4 w-full animate-pulse rounded-full bg-white/10" />
+            <div key={index} className="h-4 w-full animate-pulse rounded-full bg-[color:var(--elev-2)]/60" />
           ))}
         </div>
-        <div className="h-36 animate-pulse rounded-2xl bg-white/10" />
+        <div className="h-36 animate-pulse rounded-2xl bg-[color:var(--elev-2)]/60" />
       </div>
-    )
+    );
   }
 
-  const isEmpty = keywords.length === 0 && temporal.length === 0 && actors.length === 0 && spikes.length === 0
+  const isEmpty = keywords.length === 0 && temporal.length === 0 && actors.length === 0 && spikes.length === 0;
 
   if (isEmpty) {
     return (
-      <div className="card compact rounded-2xl border border-dashed border-[color:var(--border)]/70 bg-[color:var(--surface-2)]/50 p-4 text-sm text-[color:var(--muted)]">
+      <div className="card rounded-2xl border border-dashed border-[color:var(--border)]/70 bg-[color:var(--card)]/70 p-5 text-sm text-[color:var(--muted)]">
         No insights available yet. Adjust filters or try a different timeframe.
       </div>
-    )
+    );
   }
 
   return (
-    <div className="card compact space-y-6 rounded-2xl border border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/60 p-4 shadow-sm shadow-black/5">
-      <header>
-        <h3 className="text-base font-semibold text-[color:var(--text)]">Insights snapshot</h3>
-        <p className="text-xs text-[color:var(--muted)]">Top signals from the current GDELT aggregation.</p>
+    <div className="card flex h-full flex-col gap-6 rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--card)]/90 p-5">
+      <header className="space-y-1">
+        <h3 className="text-base font-semibold text-[color:var(--fg)]">Insights snapshot</h3>
+        <p className="meta">Top signals from the current GDELT aggregation.</p>
       </header>
 
       {keywords.length > 0 && (
         <section>
-          <h4 className="text-xs font-semibold uppercase tracking-wide text-[color:var(--muted)]">Top keywords</h4>
+          <h4 className="meta uppercase tracking-[0.2em]">Top keywords</h4>
           <ul className="mt-3 space-y-2">
             {keywords.map((entry) => (
-              <li key={entry.keyword} className="flex items-center justify-between rounded-xl bg-[color:var(--surface-3)]/40 px-3 py-2 text-sm">
-                <span className="font-medium text-[color:var(--text)]">{entry.keyword}</span>
-                <span className="rounded-full bg-[color:var(--primary)]/15 px-2 py-0.5 text-xs font-semibold text-[color:var(--primary)]">
+              <li
+                key={entry.keyword}
+                className="flex items-center justify-between rounded-xl bg-[color:var(--panel)]/50 px-3 py-2 text-sm"
+              >
+                <span className="font-medium text-[color:var(--fg)]">{entry.keyword}</span>
+                <span className="pill px-2 py-0 text-xs font-semibold text-[color:var(--accent-light)]">
                   {entry.count.toLocaleString()}
                 </span>
               </li>
@@ -182,38 +185,38 @@ export function InsightsPanel({ insights, isLoading = false, error }: InsightsPa
       {temporal.length > 0 && (
         <section className="space-y-3">
           <div className="flex items-center justify-between">
-            <h4 className="text-xs font-semibold uppercase tracking-wide text-[color:var(--muted)]">Temporal distribution</h4>
+            <h4 className="meta uppercase tracking-[0.2em]">Temporal distribution</h4>
             {spikes.length > 0 && (
-              <div className="flex items-center gap-2 text-xs">
+              <div className="flex items-center gap-2 text-xs text-[color:var(--accent-light)]">
                 {spikes.map((label) => (
-                  <span key={label} className="rounded-full bg-red-500/15 px-2 py-0.5 font-semibold text-red-300">
+                  <span key={label} className="pill px-2 py-0 text-xs font-semibold text-[color:var(--accent-light)]">
                     ⚠️ {label}
                   </span>
                 ))}
               </div>
             )}
           </div>
-          <div className="h-40 rounded-2xl bg-[color:var(--surface-3)]/30 p-3">
+          <div className="h-40 rounded-2xl border border-[color:var(--border)]/60 bg-[color:var(--panel)]/40 p-3">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={temporal} margin={{ top: 8, left: 0, right: 0, bottom: 0 }}>
                 <defs>
                   <linearGradient id="insightsBar" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="#f87171" stopOpacity={0.9} />
-                    <stop offset="95%" stopColor="#f87171" stopOpacity={0.2} />
+                    <stop offset="5%" stopColor="#FF6B6B" stopOpacity={0.9} />
+                    <stop offset="95%" stopColor="#FF6B6B" stopOpacity={0.2} />
                   </linearGradient>
                 </defs>
-                <XAxis dataKey="label" tick={{ fill: "var(--muted-foreground)", fontSize: 11 }} tickLine={false} axisLine={false} hide={temporal.length > 8} />
-                <YAxis tick={{ fill: "var(--muted-foreground)", fontSize: 11 }} tickLine={false} axisLine={false} width={42} />
+                <XAxis dataKey="label" tick={{ fill: "var(--muted)", fontSize: 11 }} tickLine={false} axisLine={false} hide={temporal.length > 8} />
+                <YAxis tick={{ fill: "var(--muted)", fontSize: 11 }} tickLine={false} axisLine={false} width={42} />
                 <Tooltip
-                  cursor={{ fill: "rgba(248,113,113,0.1)" }}
+                  cursor={{ fill: "rgba(255,107,107,0.12)" }}
                   contentStyle={{
                     borderRadius: 12,
-                    border: "none",
-                    background: "var(--surface)",
-                    boxShadow: "0 12px 30px rgba(0,0,0,0.25)",
+                    border: "1px solid rgba(255,255,255,0.05)",
+                    background: "var(--panel)",
+                    boxShadow: "0 15px 45px rgba(0,0,0,0.4)",
                   }}
                   formatter={(value: number) => [value.toLocaleString(), "Mentions"]}
-                  labelStyle={{ fontWeight: 600 }}
+                  labelStyle={{ fontWeight: 600, color: "var(--fg)" }}
                 />
                 <Bar dataKey="value" fill="url(#insightsBar)" radius={[12, 12, 4, 4]} />
               </BarChart>
@@ -224,16 +227,16 @@ export function InsightsPanel({ insights, isLoading = false, error }: InsightsPa
 
       {actors.length > 0 && (
         <section>
-          <h4 className="text-xs font-semibold uppercase tracking-wide text-[color:var(--muted)]">Top actors</h4>
+          <h4 className="meta uppercase tracking-[0.2em]">Top actors</h4>
           <div className="mt-3 flex flex-wrap gap-2">
             {actors.map((actor) => (
               <span
                 key={actor.name}
-                className="inline-flex items-center gap-2 rounded-full border border-[color:var(--primary)]/40 bg-[color:var(--surface-3)]/40 px-3 py-1 text-xs font-medium text-[color:var(--text)]"
+                className="pill gap-2 border-[color:var(--violet)]/40 bg-[color:var(--violet)]/15 text-xs font-medium text-[color:var(--violet-light)]"
               >
                 {actor.name}
                 {typeof actor.count === "number" && (
-                  <span className="rounded-full bg-[color:var(--primary)]/20 px-2 py-0.5 text-[color:var(--primary)]">
+                  <span className="rounded-full bg-[color:var(--panel)]/60 px-2 py-0.5 text-[color:var(--fg)]">
                     {actor.count.toLocaleString()}
                   </span>
                 )}
@@ -243,7 +246,7 @@ export function InsightsPanel({ insights, isLoading = false, error }: InsightsPa
         </section>
       )}
     </div>
-  )
+  );
 }
 
-export default InsightsPanel
+export default InsightsPanel;

--- a/src/components/gdelt/KpiCards.tsx
+++ b/src/components/gdelt/KpiCards.tsx
@@ -1,42 +1,44 @@
-"use client"
+"use client";
 
-import clsx from "clsx"
-import { ArrowDownRight, ArrowUpRight } from "lucide-react"
-import { ReactNode, useMemo } from "react"
+import clsx from "clsx";
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+import { ReactNode, useMemo } from "react";
 
 interface KpiCardsProps {
-  totalEvents?: number
-  avgTone?: number
-  avgImpact?: number
-  topPair?: string
-  isLoading?: boolean
-  error?: string | null
+  totalEvents?: number;
+  avgTone?: number;
+  avgImpact?: number;
+  topPair?: string;
+  isLoading?: boolean;
+  error?: string | null;
 }
 
 interface KpiCardProps {
-  label: string
-  value: ReactNode
-  trend?: number | null
+  label: string;
+  value: ReactNode;
+  trend?: number | null;
 }
 
 const formatNumber = (value?: number, options?: Intl.NumberFormatOptions) => {
   if (value === null || value === undefined || Number.isNaN(value)) {
-    return "—"
+    return "—";
   }
-  return value.toLocaleString(undefined, options)
-}
+  return value.toLocaleString(undefined, options);
+};
 
 const TrendIndicator = ({ value }: { value: number }) => {
-  if (!value) return null
+  if (!value) return null;
 
-  const isPositive = value > 0
-  const Icon = isPositive ? ArrowUpRight : ArrowDownRight
+  const isPositive = value > 0;
+  const Icon = isPositive ? ArrowUpRight : ArrowDownRight;
 
   return (
     <span
       className={clsx(
-        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
-        isPositive ? "bg-emerald-500/10 text-emerald-400" : "bg-red-500/10 text-red-400"
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium transition",
+        isPositive
+          ? "bg-emerald-500/15 text-emerald-300"
+          : "bg-[color:var(--accent)]/20 text-[color:var(--accent-light)]",
       )}
     >
       <Icon className="h-3.5 w-3.5" strokeWidth={2} />
@@ -45,20 +47,20 @@ const TrendIndicator = ({ value }: { value: number }) => {
         minimumFractionDigits: 0,
       })}
     </span>
-  )
-}
+  );
+};
 
 const KpiCard = ({ label, value, trend }: KpiCardProps) => {
   return (
-    <div className="card compact relative overflow-hidden rounded-2xl border border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/50 p-4 shadow-sm shadow-black/5">
-      <h3 className="text-sm font-medium text-[color:var(--muted)]">{label}</h3>
-      <div className="mt-2 flex items-baseline gap-3">
-        <p className="text-2xl font-semibold tracking-tight text-[color:var(--text)] tabular-nums">{value}</p>
+    <div className="card flex flex-col gap-3 rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--card)]/90 p-5">
+      <p className="meta uppercase tracking-[0.12em]">{label}</p>
+      <div className="flex items-baseline gap-3">
+        <p className="kpi tabular-nums">{value}</p>
         {typeof trend === "number" && trend !== 0 ? <TrendIndicator value={trend} /> : null}
       </div>
     </div>
-  )
-}
+  );
+};
 
 export function KpiCards({
   totalEvents,
@@ -89,15 +91,15 @@ export function KpiCards({
         value: topPair ?? "—",
       },
     ],
-    [avgImpact, avgTone, topPair, totalEvents]
-  )
+    [avgImpact, avgTone, topPair, totalEvents],
+  );
 
   if (error) {
     return (
-      <div className="rounded-2xl border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-100">
+      <div className="card rounded-2xl border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/10 p-5 text-sm text-[color:var(--accent-light)]">
         {error}
       </div>
-    )
+    );
   }
 
   if (isLoading) {
@@ -106,11 +108,11 @@ export function KpiCards({
         {Array.from({ length: 4 }).map((_, index) => (
           <div
             key={index}
-            className="card compact h-24 animate-pulse rounded-2xl bg-gradient-to-br from-[color:var(--surface-2)] via-[color:var(--surface-3)] to-[color:var(--surface-2)]"
+            className="card h-28 animate-pulse rounded-2xl bg-[color:var(--elev-2)]/60"
           />
         ))}
       </div>
-    )
+    );
   }
 
   return (
@@ -119,5 +121,5 @@ export function KpiCards({
         <KpiCard key={item.label} label={item.label} value={item.value} trend={item.trend ?? undefined} />
       ))}
     </div>
-  )
+  );
 }

--- a/src/components/poly/PolyMarketGrid.tsx
+++ b/src/components/poly/PolyMarketGrid.tsx
@@ -1,77 +1,77 @@
-"use client"
+"use client";
 
-import Link from "next/link"
-import clsx from "clsx"
+import Link from "next/link";
+import clsx from "clsx";
 
-import type { PolyMarket } from "@/types"
+import type { PolyMarket } from "@/types";
 
 interface PolyMarketGridProps {
-  markets: PolyMarket[]
-  onOpen?: (id: string) => void
-  isLoading?: boolean
-  error?: string | null
+  markets: PolyMarket[];
+  onOpen?: (id: string) => void;
+  isLoading?: boolean;
+  error?: string | null;
 }
 
 const formatNumber = (value?: number) => {
   if (value === null || value === undefined || Number.isNaN(value)) {
-    return "—"
+    return "—";
   }
 
   if (Math.abs(value) >= 1_000_000) {
     return `${(value / 1_000_000).toLocaleString(undefined, {
       maximumFractionDigits: 1,
-    })}M`
+    })}M`;
   }
 
   if (Math.abs(value) >= 1_000) {
     return `${(value / 1_000).toLocaleString(undefined, {
       maximumFractionDigits: 1,
-    })}K`
+    })}K`;
   }
 
-  return value.toLocaleString(undefined, { maximumFractionDigits: 2 })
-}
+  return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+};
 
 const formatPrice = (value?: number) => {
   if (value === null || value === undefined || Number.isNaN(value)) {
-    return "—"
+    return "—";
   }
 
   return value.toLocaleString(undefined, {
     style: "percent",
     minimumFractionDigits: 1,
     maximumFractionDigits: 1,
-  })
-}
+  });
+};
 
 const formatDate = (value: string | null) => {
   if (!value) {
-    return "—"
+    return "—";
   }
 
-  const date = new Date(value)
+  const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
-    return value
+    return value;
   }
 
   return date.toLocaleDateString(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",
-  })
-}
+  });
+};
 
 const statusStyles: Record<string, string> = {
-  active: "bg-emerald-500/10 text-emerald-400 border border-emerald-500/30",
-  trading: "bg-emerald-500/10 text-emerald-400 border border-emerald-500/30",
+  active: "bg-emerald-500/15 text-emerald-300 border border-emerald-500/40",
+  trading: "bg-emerald-500/15 text-emerald-300 border border-emerald-500/40",
   expired: "bg-[color:var(--muted)]/10 text-[color:var(--muted)] border border-[color:var(--muted)]/30",
-  resolved: "bg-blue-500/10 text-blue-300 border border-blue-500/30",
-}
+  resolved: "bg-[color:var(--violet)]/15 text-[color:var(--violet-light)] border border-[color:var(--violet)]/40",
+};
 
 const getStatusClass = (status: string) => {
-  const normalized = status.toLowerCase()
-  return statusStyles[normalized] ?? "bg-[color:var(--surface-3)] text-[color:var(--muted)] border border-[color:var(--border)]/50"
-}
+  const normalized = status.toLowerCase();
+  return statusStyles[normalized] ?? "bg-[color:var(--panel)]/60 text-[color:var(--muted)] border border-[color:var(--border)]/60";
+};
 
 export function PolyMarketGrid({
   markets,
@@ -81,49 +81,46 @@ export function PolyMarketGrid({
 }: PolyMarketGridProps) {
   if (error) {
     return (
-      <div className="rounded-3xl border border-red-400/40 bg-red-500/10 p-4 text-sm text-red-200">
+      <div className="card rounded-2xl border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/10 p-5 text-sm text-[color:var(--accent-light)]">
         <p className="font-medium">Unable to load Polymarket data</p>
         <p className="mt-1 opacity-80">{error}</p>
       </div>
-    )
+    );
   }
 
   if (isLoading) {
     return (
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {Array.from({ length: 6 }).map((_, index) => (
-          <div
-            key={index}
-            className="card h-48 animate-pulse rounded-3xl bg-gradient-to-br from-[color:var(--surface-2)] via-[color:var(--surface-3)] to-[color:var(--surface-2)]"
-          />
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="card h-48 animate-pulse rounded-2xl bg-[color:var(--elev-2)]/60" />
         ))}
       </div>
-    )
+    );
   }
 
   if (!markets || markets.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center rounded-3xl bg-gradient-to-br from-[color:var(--surface)] to-[color:var(--surface-2)] p-6 text-sm text-[color:var(--muted)]">
+      <div className="card flex h-full min-h-[220px] flex-col items-center justify-center rounded-2xl border border-dashed border-[color:var(--border)]/70 bg-[color:var(--card)]/70 p-6 text-sm text-[color:var(--muted)]">
         <p>No markets matched the current filters.</p>
       </div>
-    )
+    );
   }
 
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
       {markets.map((market) => (
         <div
           key={market.id}
-          className="card flex h-full flex-col justify-between rounded-3xl border border-[color:var(--border)]/50 bg-[color:var(--surface-2)]/60 p-4 shadow-lg shadow-black/5"
+          className="card flex h-full flex-col gap-4 rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--card)]/90 p-5"
         >
           <div className="flex flex-col gap-4">
             <div className="flex items-start justify-between gap-3">
-              <h3 className="line-clamp-2 text-lg font-semibold leading-snug text-[color:var(--text)]">
+              <h3 className="line-clamp-2 text-base font-semibold leading-snug text-[color:var(--fg)]">
                 {market.title || "Untitled market"}
               </h3>
               <span
                 className={clsx(
-                  "ml-auto rounded-full px-3 py-1 text-xs font-medium capitalize",
+                  "pill px-3 py-0 text-xs font-medium capitalize",
                   getStatusClass(market.status),
                 )}
               >
@@ -132,37 +129,37 @@ export function PolyMarketGrid({
             </div>
 
             <div className="flex flex-wrap gap-2">
-              <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300">
+              <span className="pill gap-2 border-emerald-400/40 bg-emerald-500/10 text-xs font-medium text-emerald-200">
                 <span className="font-semibold">YES</span>
                 <span>{formatPrice(market.priceYes)}</span>
               </span>
-              <span className="inline-flex items-center gap-2 rounded-full border border-red-500/40 bg-red-500/10 px-3 py-1 text-xs font-medium text-red-300">
+              <span className="pill gap-2 border-[color:var(--accent)]/40 bg-[color:var(--accent)]/15 text-xs font-medium text-[color:var(--accent-light)]">
                 <span className="font-semibold">NO</span>
                 <span>{formatPrice(market.priceNo)}</span>
               </span>
             </div>
 
-            <dl className="grid grid-cols-2 gap-3 text-xs text-[color:var(--muted)] sm:grid-cols-3">
+            <dl className="grid grid-cols-2 gap-4 text-xs text-[color:var(--muted)]">
               <div>
-                <dt className="font-medium text-[color:var(--muted)]">Volume 24h</dt>
-                <dd className="mt-1 text-sm font-semibold text-[color:var(--text)]">${formatNumber(market.volume24h)}</dd>
+                <dt className="font-medium uppercase tracking-[0.18em]">Volume 24h</dt>
+                <dd className="mt-1 text-sm font-semibold text-[color:var(--fg)]">${formatNumber(market.volume24h)}</dd>
               </div>
               <div>
-                <dt className="font-medium text-[color:var(--muted)]">Liquidity</dt>
-                <dd className="mt-1 text-sm font-semibold text-[color:var(--text)]">${formatNumber(market.liquidity)}</dd>
+                <dt className="font-medium uppercase tracking-[0.18em]">Liquidity</dt>
+                <dd className="mt-1 text-sm font-semibold text-[color:var(--fg)]">${formatNumber(market.liquidity)}</dd>
               </div>
-              <div className="sm:col-span-1">
-                <dt className="font-medium text-[color:var(--muted)]">End Date</dt>
-                <dd className="mt-1 text-sm font-semibold text-[color:var(--text)]">{formatDate(market.endDate)}</dd>
+              <div className="col-span-2">
+                <dt className="font-medium uppercase tracking-[0.18em]">End Date</dt>
+                <dd className="mt-1 text-sm font-semibold text-[color:var(--fg)]">{formatDate(market.endDate)}</dd>
               </div>
             </dl>
           </div>
 
-          <div className="mt-6 flex flex-col gap-2 sm:flex-row sm:items-center">
+          <div className="mt-auto grid grid-cols-1 gap-2 sm:grid-cols-2">
             <button
               type="button"
               onClick={() => onOpen?.(market.id)}
-              className="inline-flex w-full items-center justify-center rounded-full bg-[color:var(--primary)] px-4 py-2 text-sm font-semibold text-white shadow-sm shadow-[color:var(--primary)]/30 transition hover:bg-[color:var(--primary-stronger)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--primary)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)]"
+              className="pill-active inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold shadow-none transition hover:brightness-110"
             >
               Open
             </button>
@@ -170,7 +167,7 @@ export function PolyMarketGrid({
               href={market.id ? `https://polymarket.com/market/${market.id}` : "https://polymarket.com"}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex w-full items-center justify-center rounded-full border border-[color:var(--primary)]/40 bg-transparent px-4 py-2 text-sm font-semibold text-[color:var(--primary)] transition hover:bg-[color:var(--primary)]/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--primary)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)]"
+              className="pill inline-flex items-center justify-center px-4 py-2 text-sm font-semibold text-[color:var(--accent-light)] transition hover:border-[color:var(--accent)]/50 hover:bg-[color:var(--accent)]/10"
             >
               View on Polymarket
             </Link>
@@ -178,5 +175,5 @@ export function PolyMarketGrid({
         </div>
       ))}
     </div>
-  )
+  );
 }

--- a/src/components/system/ActivityPanel.tsx
+++ b/src/components/system/ActivityPanel.tsx
@@ -1,99 +1,99 @@
-"use client"
+"use client";
 
-import clsx from "clsx"
+import clsx from "clsx";
 
 interface DatasetStatus {
-  id: string
-  label: string
-  lastFetched?: string
-  status?: "green" | "yellow" | "red"
-  fallback?: string | null
-  enabled?: boolean
+  id: string;
+  label: string;
+  lastFetched?: string;
+  status?: "green" | "yellow" | "red";
+  fallback?: string | null;
+  enabled?: boolean;
 }
 
 interface RecentQuery {
-  query: string
-  timestamp: string
-  dataset?: string
+  query: string;
+  timestamp: string;
+  dataset?: string;
 }
 
 interface ActivityPanelProps {
-  datasets?: DatasetStatus[]
-  recentQueries?: RecentQuery[]
-  isLoading?: boolean
-  error?: string | null
+  datasets?: DatasetStatus[];
+  recentQueries?: RecentQuery[];
+  isLoading?: boolean;
+  error?: string | null;
 }
 
 const STATUS_ICON: Record<NonNullable<DatasetStatus["status"]>, string> = {
   green: "🟢",
   yellow: "🟡",
   red: "🔴",
-}
+};
 
 const formatTimestamp = (value?: string) => {
-  if (!value) return "—"
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return value
-  return date.toISOString().replace("T", " ").slice(0, 19)
-}
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toISOString().replace("T", " ").slice(0, 19);
+};
 
 export function ActivityPanel({ datasets = [], recentQueries = [], isLoading = false, error }: ActivityPanelProps) {
   if (error) {
     return (
-      <div className="card compact rounded-2xl border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-100">
+      <div className="card rounded-2xl border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/10 p-5 text-sm text-[color:var(--accent-light)]">
         {error}
       </div>
-    )
+    );
   }
 
   if (isLoading) {
     return (
-      <div className="card compact space-y-4 rounded-2xl bg-gradient-to-br from-[color:var(--surface-2)] via-[color:var(--surface-3)] to-[color:var(--surface-2)] p-4">
-        <div className="h-5 w-48 animate-pulse rounded-full bg-white/10" />
+      <div className="card space-y-4 rounded-2xl bg-[color:var(--card)]/70 p-5">
+        <div className="h-5 w-48 animate-pulse rounded-full bg-[color:var(--elev-2)]/70" />
         <div className="space-y-2">
           {Array.from({ length: 3 }).map((_, index) => (
-            <div key={`dataset-${index}`} className="h-5 w-full animate-pulse rounded-full bg-white/10" />
+            <div key={`dataset-${index}`} className="h-5 w-full animate-pulse rounded-full bg-[color:var(--elev-2)]/60" />
           ))}
         </div>
         <div className="space-y-2">
           {Array.from({ length: 4 }).map((_, index) => (
-            <div key={`query-${index}`} className="h-4 w-full animate-pulse rounded-full bg-white/10" />
+            <div key={`query-${index}`} className="h-4 w-full animate-pulse rounded-full bg-[color:var(--elev-2)]/60" />
           ))}
         </div>
       </div>
-    )
+    );
   }
 
-  const hasContent = datasets.length > 0 || recentQueries.length > 0
+  const hasContent = datasets.length > 0 || recentQueries.length > 0;
 
   if (!hasContent) {
     return (
-      <div className="card compact rounded-2xl border border-dashed border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/50 p-4 text-sm text-[color:var(--muted)]">
+      <div className="card rounded-2xl border border-dashed border-[color:var(--border)]/70 bg-[color:var(--card)]/70 p-5 text-sm text-[color:var(--muted)]">
         Activity will appear here once datasets begin syncing.
       </div>
-    )
+    );
   }
 
   return (
-    <div className="card compact space-y-6 rounded-2xl border border-[color:var(--border)]/60 bg-[color:var(--surface-2)]/60 p-4 shadow-sm shadow-black/5">
+    <div className="card flex h-full flex-col gap-6 rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--card)]/90 p-5">
       <header>
-        <h3 className="text-base font-semibold text-[color:var(--text)]">System activity</h3>
-        <p className="text-xs text-[color:var(--muted)]">Latest synchronization status across connected datasets.</p>
+        <h3 className="text-base font-semibold text-[color:var(--fg)]">System activity</h3>
+        <p className="meta mt-1">Latest synchronization status across connected datasets.</p>
       </header>
 
       {datasets.length > 0 && (
         <section className="space-y-3">
-          <h4 className="text-xs font-semibold uppercase tracking-wide text-[color:var(--muted)]">Dataset health</h4>
+          <h4 className="meta uppercase tracking-[0.2em]">Dataset health</h4>
           <ul className="space-y-2 text-sm">
             {datasets.map((dataset) => {
-              const statusIcon = dataset.status ? STATUS_ICON[dataset.status] : ""
+              const statusIcon = dataset.status ? STATUS_ICON[dataset.status] : "";
               return (
                 <li
                   key={dataset.id}
-                  className="flex flex-wrap items-center justify-between gap-3 rounded-xl bg-[color:var(--surface-3)]/40 px-3 py-2"
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[color:var(--border)]/60 bg-[color:var(--panel)]/40 px-3 py-2"
                 >
                   <div className="flex flex-col">
-                    <span className="font-medium text-[color:var(--text)]">
+                    <span className="font-medium text-[color:var(--fg)]">
                       {statusIcon && <span className="mr-2 align-middle text-lg">{statusIcon}</span>}
                       {dataset.label}
                     </span>
@@ -103,23 +103,23 @@ export function ActivityPanel({ datasets = [], recentQueries = [], isLoading = f
                   </div>
                   <div className="flex items-center gap-2 text-xs">
                     {dataset.fallback && (
-                      <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 font-medium text-amber-300">
+                      <span className="pill px-2 py-0 text-xs font-semibold text-amber-300">
                         ⚠️ {dataset.fallback}
                       </span>
                     )}
                     <span
                       className={clsx(
-                        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 font-medium",
+                        "pill px-2 py-0 text-xs font-semibold",
                         dataset.enabled
-                          ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-300"
-                          : "border-red-400/40 bg-red-500/10 text-red-200"
+                          ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-200"
+                          : "border-[color:var(--accent)]/40 bg-[color:var(--accent)]/15 text-[color:var(--accent-light)]",
                       )}
                     >
                       {dataset.enabled ? "Enabled" : "Disabled"}
                     </span>
                   </div>
                 </li>
-              )
+              );
             })}
           </ul>
         </section>
@@ -127,16 +127,16 @@ export function ActivityPanel({ datasets = [], recentQueries = [], isLoading = f
 
       {recentQueries.length > 0 && (
         <section className="space-y-3">
-          <h4 className="text-xs font-semibold uppercase tracking-wide text-[color:var(--muted)]">Recent queries</h4>
+          <h4 className="meta uppercase tracking-[0.2em]">Recent queries</h4>
           <ul className="space-y-2 text-xs">
             {recentQueries.slice(0, 6).map((item, index) => (
               <li
                 key={`${item.timestamp}-${index}`}
-                className="flex items-center justify-between rounded-xl border border-[color:var(--border)]/50 bg-[color:var(--surface-3)]/30 px-3 py-2"
+                className="flex items-center justify-between rounded-xl border border-[color:var(--border)]/60 bg-[color:var(--panel)]/40 px-3 py-2"
               >
-                <span className="truncate text-[color:var(--text)]">
+                <span className="truncate text-[color:var(--fg)]">
                   {item.dataset ? (
-                    <span className="mr-2 rounded-full bg-[color:var(--primary)]/15 px-2 py-0.5 font-semibold text-[color:var(--primary)]">
+                    <span className="pill mr-2 px-2 py-0 text-xs font-semibold text-[color:var(--accent-light)]">
                       {item.dataset}
                     </span>
                   ) : null}
@@ -149,7 +149,7 @@ export function ActivityPanel({ datasets = [], recentQueries = [], isLoading = f
         </section>
       )}
     </div>
-  )
+  );
 }
 
-export default ActivityPanel
+export default ActivityPanel;

--- a/src/components/twitter/TwitterPlaceholder.tsx
+++ b/src/components/twitter/TwitterPlaceholder.tsx
@@ -38,12 +38,12 @@ type TwitterApiResponse = PlaceholderTweet[] | { data?: PlaceholderTweet[] | nul
 
 function TweetSkeleton() {
   return (
-    <div className="flex animate-pulse gap-3 rounded-2xl border border-[color:var(--surface-3)]/20 bg-gradient-to-br from-[color:var(--surface-2)] to-[color:var(--surface-3)] p-3 shadow-inner shadow-black/5">
-      <div className="h-10 w-10 rounded-full bg-[color:var(--surface-4)]" />
+    <div className="flex animate-pulse gap-3 rounded-2xl border border-[color:var(--border)]/40 bg-[color:var(--panel)]/40 p-3">
+      <div className="h-10 w-10 rounded-full bg-[color:var(--elev-2)]/60" />
       <div className="flex-1 space-y-2">
-        <div className="h-3 w-32 rounded-full bg-[color:var(--surface-4)]" />
-        <div className="h-3 w-full rounded-full bg-[color:var(--surface-4)]" />
-        <div className="h-3 w-5/6 rounded-full bg-[color:var(--surface-4)]" />
+        <div className="h-3 w-32 rounded-full bg-[color:var(--elev-2)]/60" />
+        <div className="h-3 w-full rounded-full bg-[color:var(--elev-2)]/60" />
+        <div className="h-3 w-5/6 rounded-full bg-[color:var(--elev-2)]/60" />
       </div>
     </div>
   );
@@ -51,12 +51,12 @@ function TweetSkeleton() {
 
 function TweetCard({ tweet }: { tweet: PlaceholderTweet }) {
   return (
-    <article className="group flex flex-col gap-2 rounded-2xl border border-[color:var(--surface-3)]/20 bg-gradient-to-br from-[color:var(--surface-2)] to-[color:var(--surface-3)] p-3 shadow-lg shadow-black/5 transition hover:border-[color:var(--primary)]/40 hover:shadow-[0_20px_45px_-30px_var(--primary)]">
+    <article className="group flex flex-col gap-2 rounded-2xl border border-[color:var(--border)]/50 bg-[color:var(--panel)]/50 p-3 transition hover:border-[color:var(--accent)]/60 hover:bg-[color:var(--accent)]/10">
       <header className="flex items-center justify-between gap-3 text-sm">
         <div className="flex min-w-0 items-center gap-3">
-          <div className="h-10 w-10 flex-shrink-0 rounded-full bg-[color:var(--primary)]/20" />
+          <div className="h-10 w-10 flex-shrink-0 rounded-full bg-[color:var(--accent)]/20" />
           <div className="min-w-0">
-            <p className="truncate font-medium text-[color:var(--text)]">
+            <p className="truncate font-medium text-[color:var(--fg)]">
               {tweet.author ?? "Unknown handle"}
             </p>
             {tweet.createdAt ? (
@@ -69,13 +69,13 @@ function TweetCard({ tweet }: { tweet: PlaceholderTweet }) {
             href={tweet.url}
             target="_blank"
             rel="noreferrer"
-            className="inline-flex items-center rounded-full border border-[color:var(--surface-4)] bg-[color:var(--surface)] px-3 py-1 text-xs font-medium text-[color:var(--primary)] transition hover:border-[color:var(--primary)] hover:bg-[color:var(--primary)]/10"
+            className="pill px-3 py-0 text-xs font-semibold text-[color:var(--accent-light)] hover:border-[color:var(--accent)]/50 hover:bg-[color:var(--accent)]/20"
           >
             View
           </a>
         ) : null}
       </header>
-      <p className="line-clamp-4 text-sm leading-relaxed text-[color:var(--muted-foreground)]">
+      <p className="line-clamp-4 text-sm leading-relaxed text-[color:var(--muted)]">
         {tweet.text ?? "No summary available yet."}
       </p>
     </article>
@@ -142,20 +142,18 @@ export function TwitterPlaceholder({ comingSoon }: TwitterPlaceholderProps) {
   }, [comingSoon]);
 
   return (
-    <section className="card relative flex flex-col gap-4 p-4">
+    <section className="card flex h-full flex-col gap-4 rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--card)]/90 p-5">
       <header className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h2 className="text-lg font-semibold text-[color:var(--text)]">Twitter Signals</h2>
-          <p className="text-sm text-[color:var(--muted)]">
-            Curated market intelligence sourced from verified feeds.
-          </p>
+          <h2 className="text-base font-semibold text-[color:var(--fg)]">Twitter signals</h2>
+          <p className="meta mt-1">Curated market intelligence sourced from verified feeds.</p>
         </div>
       </header>
 
       {comingSoon ? (
         <div className="space-y-4">
-          <div className="rounded-full bg-[color:var(--primary)]/15 px-3 py-1 text-sm font-medium text-[color:var(--primary)]">
-            Twitter Integration Coming Soon
+          <div className="pill px-3 py-0 text-sm font-semibold text-[color:var(--accent-light)]">
+            Twitter integration coming soon
           </div>
           <div className="space-y-3">
             {skeletonTweets.map((_, index) => (
@@ -170,12 +168,12 @@ export function TwitterPlaceholder({ comingSoon }: TwitterPlaceholderProps) {
           ))}
         </div>
       ) : error ? (
-        <div className="rounded-2xl border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">
+        <div className="card rounded-2xl border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/10 p-4 text-sm text-[color:var(--accent-light)]">
           Unable to load Twitter data.
           <span className="block text-xs opacity-80">{error}</span>
         </div>
       ) : tweets.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-[color:var(--surface-4)]/60 bg-[color:var(--surface-2)]/40 p-6 text-center text-sm text-[color:var(--muted)]">
+        <div className="card rounded-2xl border border-dashed border-[color:var(--border)]/70 bg-[color:var(--card)]/70 p-6 text-center text-sm text-[color:var(--muted)]">
           No Twitter updates available yet.
         </div>
       ) : (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,25 +14,27 @@ const config: Config = {
     extend: {
       colors: {
         bg: "var(--bg)",
-        surface: "var(--surface)",
-        surface2: "var(--surface-2)",
-        primary: "var(--primary)",
-        primary600: "var(--primary-600)",
-        accent: "var(--accent)",
-        success: "var(--success)",
-        text: "var(--text)",
+        panel: "var(--panel)",
+        card: "var(--card)",
+        fg: "var(--fg)",
         muted: "var(--muted)",
         border: "var(--border)",
+        accent: "var(--accent)",
+        "accent-light": "var(--accent-light)",
+        "accent-dark": "var(--accent-dark)",
+        violet: "var(--violet)",
+        "violet-light": "var(--violet-light)",
+        "violet-dark": "var(--violet-dark)",
       },
       fontFamily: {
         sans: ["Poppins", "sans-serif"],
       },
       boxShadow: {
-        soft: "0 30px 60px -30px rgba(9, 11, 17, 0.55)",
+        glow: "0 20px 60px rgba(0,0,0,0.35)",
       },
       backgroundImage: {
-        "surface-gradient":
-          "linear-gradient(135deg, rgba(22,24,28,0.95) 0%, rgba(27,30,36,0.85) 100%)",
+        "glow-red": "var(--grad-red)",
+        "glow-violet": "var(--grad-violet)",
       },
     },
   },
@@ -42,12 +44,6 @@ const config: Config = {
       addUtilities({
         ".h1": {
           "@apply text-2xl md:text-3xl font-semibold tracking-tight": {},
-        },
-        ".card": {
-          "@apply rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-[0_8px_30px_rgba(0,0,0,0.25)] p-4": {},
-        },
-        ".surface-pill": {
-          "@apply bg-gradient-to-b from-[var(--surface-2)] to-[var(--surface)] ring-inset ring-1 ring-white/5 shadow-md": {},
         },
       });
     }),


### PR DESCRIPTION
## Summary
- add the new theme tokens and reusable utility classes that power the refreshed card, pill, and icon styles
- update the application shell and dashboard layout to use the constrained container grid that fits on a single desktop viewport
- restyle the chart, event list, KPIs, insights, Polymarket, activity, and Twitter panels to the new surfaces and spacing system

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de902de458832881292c1e748541eb