### PR TITLE
Use closed flag when querying Gamma markets

### DIFF
--- a/src/app/api/poly/route.test.ts
+++ b/src/app/api/poly/route.test.ts
@@ -45,7 +45,7 @@ describe("GET /api/poly", () => {
     const response = await GET(request);
 
     expect(mockedFetchWithTimeout).toHaveBeenCalledWith(
-      "https://gamma.example/markets?active=true&limit=5",
+      "https://gamma.example/markets?closed=false&limit=5",
     );
 
     const body = await response.json();
@@ -56,5 +56,21 @@ describe("GET /api/poly", () => {
     expect(body.markets[0].id).toBe("abc123");
     expect(body.markets[0].title).toBe("Nested market");
     expect(body.markets[0].slug).toBe("nested-market");
+  });
+
+  it("passes closed=true when active filter is explicitly disabled", async () => {
+    mockedFetchWithTimeout.mockResolvedValue(
+      new Response(JSON.stringify({ markets: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const request = new Request("https://local.test/api/poly?active=false");
+    await GET(request);
+
+    expect(mockedFetchWithTimeout).toHaveBeenCalledWith(
+      "https://gamma.example/markets?closed=true&limit=30",
+    );
   });
 });

--- a/src/app/api/poly/route.ts
+++ b/src/app/api/poly/route.ts
@@ -81,12 +81,13 @@ export async function GET(req: Request) {
   const query = data.q?.trim();
   const queryTokens = toQueryTokens(query);
   const active = data.active ? data.active === 'true' : true;
+  const closed = !active;
   const limit = clampLimit(data.limit ?? 30);
   const category = data.category;
   const sort = (data.sort ?? 'volume24h') as SortField;
 
   const searchParams = new URLSearchParams({
-    active: String(active),
+    closed: String(closed),
     limit: String(limit),
   });
 


### PR DESCRIPTION
## Summary
- swap the Gamma markets query parameter from `active` to the new `closed` flag so open markets use `closed=false`
- ensure disabling the active filter inverts the flag and extend tests to cover the behavior

## Testing
- npm test -- route

------
https://chatgpt.com/codex/tasks/task_e_68df6dad6d3c83289196363b46cc7fd4