### PR TITLE
Allow API routes to fall back to public env vars

### DIFF
--- a/src/app/api/gdelt/route.ts
+++ b/src/app/api/gdelt/route.ts
@@ -24,10 +24,13 @@ const parseDate = (value: string) =>
   );
 
 export async function GET(req: Request) {
-  const baseUrl = process.env.GDELT_BASE_URL;
+  const baseUrl = process.env.GDELT_BASE_URL ?? process.env.NEXT_PUBLIC_GDELT_BASE_URL;
   if (!baseUrl) {
     return NextResponse.json(
-      { status: 'error', message: 'GDELT_BASE_URL is not configured' },
+      {
+        status: 'error',
+        message: 'GDELT_BASE_URL (or NEXT_PUBLIC_GDELT_BASE_URL) is not configured',
+      },
       { status: 500 },
     );
   }

--- a/src/app/api/poly/market/route.ts
+++ b/src/app/api/poly/market/route.ts
@@ -67,10 +67,13 @@ const extractMarketPayload = (payload: unknown): GammaMarket | null => {
 };
 
 export async function GET(req: Request) {
-  const baseUrl = process.env.POLY_GAMMA_BASE;
+  const baseUrl = process.env.POLY_GAMMA_BASE ?? process.env.NEXT_PUBLIC_POLY_GAMMA_BASE;
   if (!baseUrl) {
     return NextResponse.json(
-      { status: 'error', message: 'POLY_GAMMA_BASE is not configured' },
+      {
+        status: 'error',
+        message: 'POLY_GAMMA_BASE (or NEXT_PUBLIC_POLY_GAMMA_BASE) is not configured',
+      },
       { status: 500 },
     );
   }

--- a/src/app/api/poly/route.ts
+++ b/src/app/api/poly/route.ts
@@ -54,10 +54,13 @@ type SortField = 'volume24h' | 'liquidity' | 'endDate';
 const clampLimit = (value: number) => Math.min(Math.max(value, 5), 200);
 
 export async function GET(req: Request) {
-  const baseUrl = process.env.POLY_GAMMA_BASE;
+  const baseUrl = process.env.POLY_GAMMA_BASE ?? process.env.NEXT_PUBLIC_POLY_GAMMA_BASE;
   if (!baseUrl) {
     return NextResponse.json(
-      { status: 'error', message: 'POLY_GAMMA_BASE is not configured' },
+      {
+        status: 'error',
+        message: 'POLY_GAMMA_BASE (or NEXT_PUBLIC_POLY_GAMMA_BASE) is not configured',
+      },
       { status: 500 },
     );
   }


### PR DESCRIPTION
## Summary
- allow the GDELT API route to read the public NEXT_PUBLIC_GDELT_BASE_URL when the private variable is unset and clarify the error copy
- do the same fallback handling for the Polymarket list and market API routes so the proxy continues to work without duplicating config

## Testing
- npm test -- poly
- (with mock upstream services) curl -s 'http://localhost:3000/api/gdelt?action=context&mode=artlist&format=json&date_start=20240101&date_end=20240131'
- (with mock upstream services) curl -s 'http://localhost:3000/api/poly?limit=5'


------
https://chatgpt.com/codex/tasks/task_e_68df998e4d248328ba4af1c8411b6550