### PR TITLE
Refactor dashboard layout for fixed viewport

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,33 +5,24 @@
 :root {
   color-scheme: dark;
 
-  /* Background layers */
-  --bg: #141414;
-  --panel: #1a1a1d;
-  --card: #1e1e22;
-  --elev-2: #222227;
-
-  /* Text & borders */
-  --fg: #f2f3f5;
-  --muted: #a1a1aa;
-  --border: #2a2a2f;
-
-  /* Accents */
-  --accent: #e53935;
-  --accent-light: #ff6b6b;
-  --accent-dark: #d32f2f;
-
-  --violet: #7c4dff;
-  --violet-light: #b388ff;
-  --violet-dark: #5e35b1;
-
-  /* Glow */
-  --glow-red: rgba(229, 57, 53, 0.25);
-  --glow-violet: rgba(124, 77, 255, 0.22);
-
-  /* Gradients */
-  --grad-red: linear-gradient(180deg, #ff6b6b 0%, #e53935 70%, rgba(229, 57, 53, 0) 100%);
-  --grad-violet: linear-gradient(180deg, #b388ff 0%, #7c4dff 70%, rgba(124, 77, 255, 0) 100%);
+  --bg: #0b0b0d;
+  --fg: #ffffff;
+  --muted: #b7bbc6;
+  --border: #1a1c22;
+  --panel: rgba(255, 255, 255, 0.03);
+  --panel-strong: rgba(255, 255, 255, 0.06);
+  --card: rgba(17, 18, 24, 0.72);
+  --elev-2: rgba(28, 30, 40, 0.7);
+  --accent: #ef2d3c;
+  --accent-light: #ff7b88;
+  --accent-dark: #a4141e;
+  --violet: #7a3ff0;
+  --violet-light: #b79bff;
+  --violet-dark: #4e1bb2;
+  --glow-red: rgba(239, 45, 60, 0.2);
+  --glow-violet: rgba(122, 63, 240, 0.22);
+  --grad-red: linear-gradient(180deg, rgba(239, 45, 60, 0.55) 0%, rgba(239, 45, 60, 0) 100%);
+  --grad-violet: linear-gradient(180deg, rgba(122, 63, 240, 0.45) 0%, rgba(122, 63, 240, 0) 100%);
 }
 
 @layer base {
@@ -45,6 +36,7 @@
     min-height: 100vh;
     background-color: var(--bg);
     color: var(--fg);
+    overflow: hidden;
     @apply antialiased;
   }
 }
@@ -67,18 +59,19 @@
 
   .card {
     position: relative;
-    border-radius: 1rem;
+    border-radius: 20px;
     border: 1px solid var(--border);
-    background: var(--card);
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+    background: var(--panel);
+    backdrop-filter: blur(12px);
+    box-shadow: 0 10px 30px rgba(239, 45, 60, 0.12);
   }
 
   .card-elev {
     position: relative;
-    border-radius: 1rem;
+    border-radius: 20px;
     border: 1px solid var(--border);
-    background: var(--card);
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+    background: var(--panel);
+    backdrop-filter: blur(18px);
     overflow: hidden;
   }
 
@@ -86,8 +79,8 @@
     content: "";
     position: absolute;
     inset: 0;
-    background: radial-gradient(120% 120% at 0% 0%, var(--glow-violet), transparent 70%);
-    opacity: 0.4;
+    background: radial-gradient(120% 80% at 0% 0%, var(--glow-violet), transparent 70%);
+    opacity: 0.35;
     pointer-events: none;
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,9 @@
-import Link from "next/link";
 import type { Metadata } from "next";
 import { Poppins } from "next/font/google";
 
 import { cn } from "@/lib/utils";
 import { Toaster } from "@/components/ui/toaster";
 import "./globals.css";
-import TopBar from "@/components/TopBar";
 import { SidePanel } from "@/components/shared/SidePanel";
 import { AppQueryProvider } from "./query-client-provider";
 
@@ -30,43 +28,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={cn(
-          "min-h-screen bg-[color:var(--bg)] text-[color:var(--fg)] antialiased",
-          poppins.className,
-        )}
-      >
+      <body className={cn("bg-[color:var(--bg)] text-[color:var(--fg)] antialiased", poppins.className)}>
         <AppQueryProvider>
-          <div className="flex min-h-screen flex-col bg-[color:var(--bg)]">
-            <header className="border-b border-[color:var(--border)]/80 bg-[color:var(--panel)]/80 backdrop-blur-lg">
-              <div className="container-outer flex h-16 items-center justify-between">
-                <span className="text-lg font-semibold tracking-tight">Poly</span>
-                <nav className="flex items-center gap-6 text-sm text-[color:var(--muted)]">
-                  <Link className="transition hover:text-[color:var(--fg)]" href="/">
-                    Overview
-                  </Link>
-                  <Link className="transition hover:text-[color:var(--fg)]" href="/reports">
-                    Reports
-                  </Link>
-                  <Link className="transition hover:text-[color:var(--fg)]" href="/settings">
-                    Settings
-                  </Link>
-                </nav>
-              </div>
-            </header>
-            <TopBar />
-            <main className="flex-1 overflow-hidden">
-              <div className="container-outer flex h-full flex-col overflow-hidden py-6">
-                {children}
-              </div>
-            </main>
-            <footer className="border-t border-[color:var(--border)]/80 bg-[color:var(--panel)]/60">
-              <div className="container-outer flex h-12 items-center justify-between text-xs text-[color:var(--muted)]">
-                <span>&copy; {new Date().getFullYear()} Poly UI</span>
-                <span>Next.js · Tailwind CSS · shadcn/ui</span>
-              </div>
-            </footer>
-          </div>
+          <div className="min-h-screen bg-[color:var(--bg)]">{children}</div>
           <SidePanel />
           <Toaster />
         </AppQueryProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,672 +1,118 @@
-'use client';
-
-import { useMemo, useState, type ComponentProps } from "react";
-
-import { GdeltChart } from "@/components/gdelt/GdeltChart";
-import { GdeltEventsList } from "@/components/gdelt/GdeltEventsList";
-import { InsightsPanel } from "@/components/gdelt/InsightsPanel";
-import { KpiCards } from "@/components/gdelt/KpiCards";
-import { PolyMarketGrid } from "@/components/poly/PolyMarketGrid";
-import ActivityPanel from "@/components/system/ActivityPanel";
-import { TwitterPlaceholder } from "@/components/twitter/TwitterPlaceholder";
-import { useGdeltBBVA } from "@/hooks/useGdeltBBVA";
-import { useGdeltBilateral } from "@/hooks/useGdeltBilateral";
-import { useGdeltContext } from "@/hooks/useGdeltContext";
-import { useGdeltCountry } from "@/hooks/useGdeltCountry";
-import { usePolySearch } from "@/hooks/usePolySearch";
-import { normalizeGdeltDate } from "@/hooks/utils";
-import { useGlobalFilters } from "@/stores/useGlobalFilters";
-import { useGdeltMode } from "@/stores/useGdeltMode";
-import { useSidePanel } from "@/stores/useSidePanel";
-import type { GdeltEvent, GdeltInsights, GdeltSeriesPoint } from "@/types";
-
-type ActivityPanelProps = ComponentProps<typeof ActivityPanel>;
-type DatasetStatusEntry = NonNullable<ActivityPanelProps["datasets"]>[number];
-type RecentQueryEntry = NonNullable<ActivityPanelProps["recentQueries"]>[number];
-
-type Aggregation = "daily" | "monthly";
-
-interface ActiveGdeltData {
-  series: GdeltSeriesPoint[];
-  events: GdeltEvent[];
-  insights?: GdeltInsights;
-  aggregation: Aggregation;
-}
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
-
-const toRecordArray = (value: unknown): Record<string, unknown>[] => {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.filter((item): item is Record<string, unknown> => isRecord(item));
-};
-
-const toNumber = (value: unknown): number | undefined => {
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? value : undefined;
-  }
-
-  if (typeof value === "string" && value.trim() !== "") {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : undefined;
-  }
-
-  return undefined;
-};
-
-const extractGdeltItems = (payload: unknown): Record<string, unknown>[] => {
-  if (Array.isArray(payload)) {
-    return toRecordArray(payload);
-  }
-
-  if (!isRecord(payload)) {
-    return [];
-  }
-
-  if (Array.isArray(payload.data)) {
-    return toRecordArray(payload.data);
-  }
-
-  if (Array.isArray(payload.results)) {
-    return toRecordArray(payload.results);
-  }
-
-  if (Array.isArray(payload.series)) {
-    return toRecordArray(payload.series);
-  }
-
-  if (Array.isArray(payload.events)) {
-    return toRecordArray(payload.events);
-  }
-
-  return [];
-};
-
-const toSeriesPoint = (record: Record<string, unknown>): GdeltSeriesPoint => {
-  const dateCandidate =
-    record.DayDate ?? record.SQLDATE ?? record.date ?? record.day ?? record.timestamp ?? "";
-
-  const point: GdeltSeriesPoint = {
-    date: normalizeGdeltDate(dateCandidate),
-  };
-
-  const conflictCandidate =
-    record.conflict_events ?? record.total_events ?? record.count ?? record.value;
-  const sentimentCandidate =
-    record.avg_sentiment ?? record.average_sentiment ?? record.sentiment ?? record.avgTone;
-  const impactCandidate = record.avg_impact ?? record.average_impact ?? record.impact;
-  const interactionCandidate =
-    record.interaction_count ?? record.interactions ?? record.total_interactions;
-  const coverageCandidate =
-    record.relative_coverage ?? record.coverage ?? record.relative ?? record.relativeCoverage;
-
-  const conflictEvents = toNumber(conflictCandidate);
-  const avgSentiment = toNumber(sentimentCandidate);
-  const avgImpact = toNumber(impactCandidate);
-  const interactionCount = toNumber(interactionCandidate);
-  const relativeCoverage = toNumber(coverageCandidate);
-
-  if (conflictEvents !== undefined) {
-    point.conflict_events = conflictEvents;
-  }
-
-  if (avgSentiment !== undefined) {
-    point.avg_sentiment = avgSentiment;
-  }
-
-  if (avgImpact !== undefined) {
-    point.avg_impact = avgImpact;
-  }
-
-  if (interactionCount !== undefined) {
-    point.interaction_count = interactionCount;
-  }
-
-  if (relativeCoverage !== undefined) {
-    point.relative_coverage = relativeCoverage;
-  }
-
-  return point;
-};
-
-const toEvent = (record: Record<string, unknown>): GdeltEvent => {
-  const base: GdeltEvent = {
-    ...record,
-    SQLDATE: (record.SQLDATE ?? record.DayDate ?? record.date ?? "") as string | number,
-    SOURCEURL: typeof record.SOURCEURL === "string" ? record.SOURCEURL : "",
-    Actor1CountryCode:
-      typeof record.Actor1CountryCode === "string" ? record.Actor1CountryCode : undefined,
-    Actor2CountryCode:
-      typeof record.Actor2CountryCode === "string" ? record.Actor2CountryCode : undefined,
-    EventCode: typeof record.EventCode === "string" ? record.EventCode : undefined,
-    AvgTone: toNumber(record.AvgTone),
-  };
-
-  return base;
-};
-
-const average = (values: Array<number | undefined>): number | undefined => {
-  const filtered = values.filter((value): value is number => typeof value === "number");
-  if (filtered.length === 0) {
-    return undefined;
-  }
-  const total = filtered.reduce((sum, value) => sum + value, 0);
-  return total / filtered.length;
-};
-
-const topPairFromInsights = (insights?: GdeltInsights): string | undefined => {
-  if (!insights) {
-    return undefined;
-  }
-
-  const record = insights as Record<string, unknown>;
-
-  const direct = record.top_pair;
-  if (typeof direct === "string") {
-    return direct;
-  }
-
-  const pairsCandidate = record.top_pairs ?? record.actor_pairs ?? record.leading_pairs;
-  if (Array.isArray(pairsCandidate)) {
-    const first = pairsCandidate[0];
-    if (typeof first === "string") {
-      return first;
-    }
-    if (isRecord(first)) {
-      const label =
-        typeof first.label === "string"
-          ? first.label
-          : typeof first.pair === "string"
-          ? first.pair
-          : typeof first.name === "string"
-          ? first.name
-          : undefined;
-      if (label) {
-        return label;
-      }
-    }
-  }
-
-  return undefined;
-};
-
-const toIsoString = (timestamp?: number): string | undefined => {
-  if (!timestamp) {
-    return undefined;
-  }
-
-  if (timestamp <= 0) {
-    return undefined;
-  }
-
-  return new Date(timestamp).toISOString();
-};
-
-const DisabledDatasetCard = ({ title, description }: { title: string; description: string }) => (
-  <div className="card flex h-full min-h-[200px] flex-col items-center justify-center rounded-2xl border border-dashed border-[color:var(--border)]/70 bg-[color:var(--card)]/70 p-6 text-center">
-    <h3 className="text-base font-semibold text-[color:var(--fg)]">{title}</h3>
-    <p className="mt-2 text-sm text-[color:var(--muted)]">{description}</p>
-  </div>
-);
-
-interface QueryState {
-  dataUpdatedAt: number;
-  isError: boolean;
-  isLoading: boolean;
-  isFetching: boolean;
-  error: unknown;
-}
-
-export default function HomePage() {
-  const keywords = useGlobalFilters((state) => state.keywords);
-  const dateStart = useGlobalFilters((state) => state.dateStart);
-  const dateEnd = useGlobalFilters((state) => state.dateEnd);
-  const datasets = useGlobalFilters((state) => state.datasets);
-  const mode = useGdeltMode((state) => state.mode);
-  const modeParams = useGdeltMode((state) => state.params);
-  const openPanel = useSidePanel((state) => state.openPanel);
-
-  const [activeDate, setActiveDate] = useState<string | null>(null);
-
-  const contextParams = modeParams.context ?? { includeInsights: true, limit: 500 };
-  const countryParams = modeParams.country ?? { country: "" };
-  const bilateralParams = modeParams.bilateral ?? { country1: "", country2: "" };
-  const bbvaParams =
-    modeParams.bbva ?? ({ actor1: "", actor2: "", includeTotal: false } as const);
-
-  const contextQuery = useGdeltContext(
-    mode === "context" && datasets.gdelt
-      ? {
-          includeInsights: contextParams.includeInsights,
-          limit: contextParams.limit,
-        }
-      : {
-          dateStart: "",
-          dateEnd: "",
-        },
-  );
-
-  const countryQuery = useGdeltCountry(
-    mode === "country" && datasets.gdelt
-      ? {
-          country: countryParams.country,
-          dateStart,
-          dateEnd,
-        }
-      : {
-          country: "",
-          dateStart: "",
-          dateEnd: "",
-        },
-  );
-
-  const bilateralQuery = useGdeltBilateral(
-    mode === "bilateral" && datasets.gdelt
-      ? {
-          country1: bilateralParams.country1,
-          country2: bilateralParams.country2,
-          dateStart,
-          dateEnd,
-        }
-      : {
-          country1: "",
-          country2: "",
-          dateStart: "",
-          dateEnd: "",
-        },
-  );
-
-  const bbvaQuery = useGdeltBBVA(
-    mode === "bbva" && datasets.gdelt
-      ? {
-          actor1: bbvaParams.actor1,
-          actor2: bbvaParams.actor2,
-          dateStart,
-          dateEnd,
-          includeTotal: bbvaParams.includeTotal,
-          cameoCodes: bbvaParams.cameoCodes,
-        }
-      : {
-          actor1: "",
-          actor2: "",
-          dateStart: "",
-          dateEnd: "",
-        },
-  );
-
-  const polyQuery = usePolySearch(
-    datasets.poly
-      ? {
-          q: keywords.length > 0 ? keywords.join(" ") : undefined,
-          active: true,
-          sort: "volume24h",
-        }
-      : { enabled: false },
-  );
-
-  const activeGdeltState: QueryState = (() => {
-    if (!datasets.gdelt) {
-      return { dataUpdatedAt: 0, isError: false, isLoading: false, isFetching: false, error: null };
-    }
-
-    switch (mode) {
-      case "country":
-        return {
-          dataUpdatedAt: countryQuery.dataUpdatedAt,
-          isError: countryQuery.isError,
-          isLoading: countryQuery.isLoading,
-          isFetching: countryQuery.isFetching,
-          error: countryQuery.error,
-        };
-      case "bilateral":
-        return {
-          dataUpdatedAt: bilateralQuery.dataUpdatedAt,
-          isError: bilateralQuery.isError,
-          isLoading: bilateralQuery.isLoading,
-          isFetching: bilateralQuery.isFetching,
-          error: bilateralQuery.error,
-        };
-      case "bbva":
-        return {
-          dataUpdatedAt: bbvaQuery.dataUpdatedAt,
-          isError: bbvaQuery.isError,
-          isLoading: bbvaQuery.isLoading,
-          isFetching: bbvaQuery.isFetching,
-          error: bbvaQuery.error,
-        };
-      default:
-        return {
-          dataUpdatedAt: contextQuery.dataUpdatedAt,
-          isError: contextQuery.isError,
-          isLoading: contextQuery.isLoading,
-          isFetching: contextQuery.isFetching,
-          error: contextQuery.error,
-        };
-    }
-  })();
-
-  const activeGdeltData = useMemo<ActiveGdeltData>(() => {
-    if (!datasets.gdelt) {
-      return { series: [], events: [], aggregation: "daily" };
-    }
-
-    if (mode === "context") {
-      return {
-        series: contextQuery.data?.series ?? [],
-        events: contextQuery.data?.events ?? [],
-        insights: contextQuery.data?.insights,
-        aggregation: "daily",
-      };
-    }
-
-    const rawData =
-      mode === "country"
-        ? countryQuery.data
-        : mode === "bilateral"
-        ? bilateralQuery.data
-        : bbvaQuery.data;
-
-    const items = extractGdeltItems(rawData);
-    const series = items.map(toSeriesPoint);
-    const events = items.map(toEvent);
-
-    let insights: GdeltInsights | undefined;
-    let aggregation: Aggregation = "daily";
-
-    if (isRecord(rawData)) {
-      const rawInsights = rawData["insights"];
-      if (rawInsights && typeof rawInsights === "object") {
-        insights = rawInsights as GdeltInsights;
-      }
-
-      const aggregationCandidate =
-        rawData["aggregation"] ?? rawData["granularity"] ?? rawData["time_unit"];
-      if (
-        typeof aggregationCandidate === "string" &&
-        aggregationCandidate.toLowerCase().includes("month")
-      ) {
-        aggregation = "monthly";
-      }
-    }
-
-    return { series, events, insights, aggregation };
-  }, [
-    datasets.gdelt,
-    mode,
-    contextQuery.data,
-    countryQuery.data,
-    bilateralQuery.data,
-    bbvaQuery.data,
-  ]);
-
-  const gdeltSeries = activeGdeltData.series;
-  const gdeltEvents = activeGdeltData.events;
-  const gdeltInsights = activeGdeltData.insights;
-  const gdeltAggregation = activeGdeltData.aggregation;
-
-  const gdeltLoading =
-    datasets.gdelt && (activeGdeltState.isLoading || activeGdeltState.isFetching);
-  const gdeltError =
-    datasets.gdelt && activeGdeltState.isError
-      ? activeGdeltState.error instanceof Error
-        ? activeGdeltState.error.message
-        : "Unknown error"
-      : null;
-
-  const markets = datasets.poly ? polyQuery.data?.markets ?? [] : [];
-  const polyLoading = datasets.poly && (polyQuery.isLoading || polyQuery.isFetching);
-  const polyError =
-    datasets.poly && polyQuery.isError
-      ? polyQuery.error instanceof Error
-        ? polyQuery.error.message
-        : "Unknown error"
-      : null;
-
-  const twitterIntegrationEnabled = process.env.NEXT_PUBLIC_ENABLE_TWITTER === "1";
-  const comingSoon = !datasets.twitter || !twitterIntegrationEnabled;
-
-  const kpiValues = useMemo(
-    () => {
-      if (!datasets.gdelt) {
-        return {
-          totalEvents: undefined,
-          avgTone: undefined,
-          avgImpact: undefined,
-          topPair: undefined,
-        };
-      }
-
-      const totalEventsFromInsights =
-        typeof gdeltInsights?.total_events === "number" ? gdeltInsights.total_events : undefined;
-      const totalEventsFromSeries = gdeltSeries.reduce(
-        (sum, point) => sum + (point.conflict_events ?? 0),
-        0,
-      );
-      const totalEvents =
-        totalEventsFromInsights ?? (totalEventsFromSeries > 0 ? totalEventsFromSeries : undefined);
-
-      const avgToneFromInsights =
-        gdeltInsights &&
-        typeof gdeltInsights.sentiment_analysis === "object" &&
-        gdeltInsights.sentiment_analysis !== null &&
-        typeof gdeltInsights.sentiment_analysis.avg_tone === "number"
-          ? gdeltInsights.sentiment_analysis.avg_tone
-          : undefined;
-
-      const avgTone = avgToneFromInsights ?? average(gdeltSeries.map((point) => point.avg_sentiment));
-      const avgImpact = average(gdeltSeries.map((point) => point.avg_impact));
-      const topPair = topPairFromInsights(gdeltInsights);
-
-      return { totalEvents, avgTone, avgImpact, topPair };
-    },
-    [datasets.gdelt, gdeltInsights, gdeltSeries],
-  );
-
-  const datasetStatuses = useMemo<DatasetStatusEntry[]>(
-    () => [
-      {
-        id: "gdelt",
-        label: "GDELT",
-        lastFetched: toIsoString(activeGdeltState.dataUpdatedAt),
-        status: !datasets.gdelt
-          ? "red"
-          : gdeltError
-          ? "red"
-          : activeGdeltState.isFetching
-          ? "yellow"
-          : "green",
-        fallback: gdeltAggregation === "monthly" ? "Monthly aggregation fallback" : null,
-        enabled: datasets.gdelt,
-      },
-      {
-        id: "poly",
-        label: "Polymarket",
-        lastFetched: toIsoString(polyQuery.dataUpdatedAt),
-        status: !datasets.poly
-          ? "red"
-          : polyError
-          ? "red"
-          : polyQuery.isFetching
-          ? "yellow"
-          : "green",
-        fallback: null,
-        enabled: datasets.poly,
-      },
-      {
-        id: "twitter",
-        label: "Twitter",
-        lastFetched: undefined,
-        status: !datasets.twitter
-          ? "red"
-          : !twitterIntegrationEnabled
-          ? "yellow"
-          : "green",
-        fallback: !twitterIntegrationEnabled ? "Awaiting integration" : null,
-        enabled: datasets.twitter,
-      },
-    ],
-    [
-      activeGdeltState.dataUpdatedAt,
-      activeGdeltState.isFetching,
-      datasets.gdelt,
-      datasets.poly,
-      datasets.twitter,
-      gdeltAggregation,
-      gdeltError,
-      polyError,
-      polyQuery.dataUpdatedAt,
-      polyQuery.isFetching,
-      twitterIntegrationEnabled,
-    ],
-  );
-
-  const recentQueries = useMemo<RecentQueryEntry[]>(
-    () => {
-      const entries: RecentQueryEntry[] = [];
-      if (keywords.length === 0) {
-        return entries;
-      }
-
-      if (datasets.gdelt) {
-        entries.push({
-          query: keywords.join(", "),
-          timestamp: toIsoString(activeGdeltState.dataUpdatedAt) ?? new Date().toISOString(),
-          dataset: `GDELT (${mode.toUpperCase()})`,
-        });
-      }
-
-      if (datasets.poly) {
-        entries.push({
-          query: keywords.join(" "),
-          timestamp: toIsoString(polyQuery.dataUpdatedAt) ?? new Date().toISOString(),
-          dataset: "Polymarket",
-        });
-      }
-
-      return entries;
-    },
-    [
-      activeGdeltState.dataUpdatedAt,
-      datasets.gdelt,
-      datasets.poly,
-      keywords,
-      mode,
-      polyQuery.dataUpdatedAt,
-    ],
+"use client";
+
+import Canvas from "@/features/polymuffin/ui/layout/Canvas";
+import NavRail from "@/features/polymuffin/ui/layout/NavRail";
+import Topbar from "@/features/polymuffin/ui/layout/Topbar";
+import { H } from "@/features/polymuffin/constants/layout";
+import TimeseriesPanel from "@/features/polymuffin/ui/panels/TimeseriesPanel";
+import ActiveMarketsPanel from "@/features/polymuffin/ui/panels/ActiveMarketsPanel";
+import KpiStrip from "@/features/polymuffin/ui/panels/KpiStrip";
+import OddsDistribution from "@/features/polymuffin/ui/panels/OddsDistribution";
+import GdeltSummary from "@/features/polymuffin/ui/panels/GdeltSummary";
+import MarketsGrid from "@/features/polymuffin/ui/panels/MarketsGrid";
+import NewsList from "@/features/polymuffin/ui/panels/NewsList";
+import { usePolymuffinData } from "@/features/polymuffin/hooks/usePolymuffinData";
+
+export default function Page() {
+  const data = usePolymuffinData();
+
+  const desktop = (
+    <Canvas>
+      <div
+        className="grid h-full"
+        style={{
+          gridTemplateColumns: "72px 16px 1fr",
+          padding: "24px",
+        }}
+      >
+        <div className="h-full">
+          <NavRail />
+        </div>
+        <div />
+        <div
+          className="grid h-full gap-4"
+          style={{
+            gridTemplateRows: `${H.TOPBAR}px ${H.ROW1}px ${H.ROW2}px ${H.ROW3}px`,
+          }}
+        >
+          <Topbar loading={data.isFetchingAny} onRefresh={data.refresh} error={data.combinedError} />
+          <div className="grid h-full grid-cols-12 gap-4">
+            <div className="col-span-8 h-full overflow-hidden">
+              <TimeseriesPanel
+                enabled={data.gdelt.enabled}
+                series={data.gdelt.series}
+                aggregation={data.gdelt.aggregation}
+                loading={data.gdelt.loading}
+                error={data.gdelt.error}
+                onDateClick={data.gdelt.setActiveDate}
+              />
+            </div>
+            <div className="col-span-4 h-full overflow-hidden">
+              <ActiveMarketsPanel
+                datasets={data.activity.datasets}
+                recentQueries={data.activity.recentQueries}
+                loading={data.gdelt.loading || data.poly.loading}
+                error={data.combinedError}
+              />
+            </div>
+          </div>
+          <div className="grid h-full grid-cols-12 gap-4">
+            <div className="col-span-4 h-full overflow-hidden">
+              <KpiStrip
+                totalEvents={data.kpis.totalEvents}
+                avgTone={data.kpis.avgTone}
+                avgImpact={data.kpis.avgImpact}
+                topPair={data.kpis.topPair}
+                loading={data.gdelt.loading}
+                error={data.gdelt.error}
+              />
+            </div>
+            <div className="col-span-4 h-full overflow-hidden">
+              <OddsDistribution
+                markets={data.poly.markets}
+                enabled={data.poly.enabled}
+                loading={data.poly.loading}
+                error={data.poly.error}
+              />
+            </div>
+            <div className="col-span-4 h-full overflow-hidden">
+              <GdeltSummary
+                insights={data.gdelt.insights}
+                loading={data.gdelt.loading}
+                error={data.gdelt.error}
+              />
+            </div>
+          </div>
+          <div className="grid h-full grid-cols-12 gap-4">
+            <div className="col-span-8 h-full overflow-hidden">
+              <MarketsGrid
+                markets={data.poly.markets}
+                enabled={data.poly.enabled}
+                loading={data.poly.loading}
+                error={data.poly.error}
+                onOpenMarket={data.openMarket}
+              />
+            </div>
+            <div className="col-span-4 h-full overflow-hidden">
+              <NewsList
+                events={data.gdelt.events}
+                enabled={data.gdelt.enabled}
+                loading={data.gdelt.loading}
+                error={data.gdelt.error}
+                onOpenEvent={data.openEvent}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </Canvas>
   );
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-6">
-      <div className="grid flex-1 min-h-0 grid-cols-1 gap-6 lg:grid-cols-[minmax(0,7fr)_minmax(0,5fr)] xl:grid-cols-[minmax(0,8fr)_minmax(0,5fr)]">
-        <div className="grid min-h-0 grid-rows-[minmax(0,3fr)_minmax(0,2fr)] gap-6">
-          <section className="flex min-h-0 flex-col">
-            {datasets.gdelt ? (
-              <GdeltChart
-                series={gdeltSeries}
-                aggregation={gdeltAggregation}
-                onDateClick={(iso) => setActiveDate(iso)}
-                isLoading={gdeltLoading}
-                error={gdeltError}
-              />
-            ) : (
-              <DisabledDatasetCard
-                title="GDELT dataset disabled"
-                description="Enable the GDELT dataset from the filters to explore temporal activity."
-              />
-            )}
-          </section>
-
-          <section className="flex min-h-0 flex-col">
-            {datasets.gdelt ? (
-              <GdeltEventsList
-                events={gdeltEvents}
-                activeDate={activeDate ?? undefined}
-                onOpen={(event) =>
-                  openPanel("event", {
-                    json: event,
-                    title: typeof event.SOURCEURL === "string" ? event.SOURCEURL : "Event details",
-                    url: typeof event.SOURCEURL === "string" ? event.SOURCEURL : undefined,
-                  })
-                }
-                isLoading={gdeltLoading}
-                error={gdeltError}
-              />
-            ) : (
-              <DisabledDatasetCard
-                title="Events hidden"
-                description="Activate the GDELT stream to review the underlying source events."
-              />
-            )}
-          </section>
-        </div>
-
-        <div className="flex min-h-0 flex-col gap-6">
-          <div>
-            {datasets.gdelt ? (
-              <KpiCards
-                totalEvents={kpiValues.totalEvents}
-                avgTone={kpiValues.avgTone}
-                avgImpact={kpiValues.avgImpact}
-                topPair={kpiValues.topPair ?? undefined}
-                isLoading={gdeltLoading}
-                error={gdeltError}
-              />
-            ) : (
-              <DisabledDatasetCard
-                title="KPIs unavailable"
-                description="Turn on the GDELT feed to surface sentiment and impact metrics."
-              />
-            )}
-          </div>
-
-          <div className="grid flex-1 min-h-0 grid-cols-1 gap-6 xl:grid-cols-2">
-            <div className="min-h-0">
-              {datasets.gdelt ? (
-                <InsightsPanel insights={gdeltInsights} isLoading={gdeltLoading} error={gdeltError} />
-              ) : (
-                <DisabledDatasetCard
-                  title="Insights paused"
-                  description="Switch the GDELT dataset back on to surface keyword and actor insights."
-                />
-              )}
-            </div>
-
-            <div className="min-h-0">
-              <ActivityPanel datasets={datasetStatuses} recentQueries={recentQueries} />
-            </div>
-
-            <div className="xl:col-span-2 flex min-h-0 flex-col">
-              {datasets.poly ? (
-                <div className="card flex min-h-0 flex-col gap-5 rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--card)]/90 p-5">
-                  <div className="flex items-center justify-between">
-                    <h3 className="text-base font-semibold text-[color:var(--fg)]">Polymarket highlights</h3>
-                    <span className="meta uppercase tracking-[0.2em]">Top markets</span>
-                  </div>
-                  <div className="min-h-0 overflow-y-auto pr-1">
-                    <PolyMarketGrid
-                      markets={markets}
-                      onOpen={(id) => openPanel("market", { id })}
-                      isLoading={polyLoading}
-                      error={polyError}
-                    />
-                  </div>
-                </div>
-              ) : (
-                <DisabledDatasetCard
-                  title="Polymarket disabled"
-                  description="Enable the Polymarket dataset to browse high-liquidity markets."
-                />
-              )}
-            </div>
-
-            <div className="xl:col-span-2 min-h-0">
-              <TwitterPlaceholder comingSoon={comingSoon} />
-            </div>
-          </div>
-        </div>
+    <div className="min-h-screen bg-[color:var(--bg)] text-[color:var(--fg)]">
+      <div className="hidden lg:block">{desktop}</div>
+      <div className="flex h-screen w-full items-center justify-center px-6 text-center text-sm text-[color:var(--muted)] lg:hidden">
+        Switch to a desktop viewport (≥1024px) to access the full dashboard experience.
       </div>
     </div>
   );

--- a/src/features/polymuffin/constants/layout.ts
+++ b/src/features/polymuffin/constants/layout.ts
@@ -1,0 +1,2 @@
+export const BASE = { W: 1920, H: 1080, PAD: 24, GAP: 16, NAV: 72 } as const;
+export const H = { TOPBAR: 88, ROW1: 360, ROW2: 260, ROW3: 300 } as const;

--- a/src/features/polymuffin/hooks/usePolymuffinData.ts
+++ b/src/features/polymuffin/hooks/usePolymuffinData.ts
@@ -1,0 +1,649 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { useGdeltBBVA } from "@/hooks/useGdeltBBVA";
+import { useGdeltBilateral } from "@/hooks/useGdeltBilateral";
+import { useGdeltContext } from "@/hooks/useGdeltContext";
+import { useGdeltCountry } from "@/hooks/useGdeltCountry";
+import { usePolySearch } from "@/hooks/usePolySearch";
+import { normalizeGdeltDate } from "@/hooks/utils";
+import { useGlobalFilters } from "@/stores/useGlobalFilters";
+import { useGdeltMode } from "@/stores/useGdeltMode";
+import { useSidePanel } from "@/stores/useSidePanel";
+import type { GdeltEvent, GdeltInsights, GdeltSeriesPoint, PolyMarket } from "@/types";
+
+import type { ComponentProps } from "react";
+import type ActivityPanel from "@/components/system/ActivityPanel";
+
+type DatasetStatusEntry = NonNullable<ComponentProps<typeof ActivityPanel>["datasets"]>[number];
+type RecentQueryEntry = NonNullable<ComponentProps<typeof ActivityPanel>["recentQueries"]>[number];
+
+type QueryState = {
+  dataUpdatedAt: number;
+  isError: boolean;
+  isLoading: boolean;
+  isFetching: boolean;
+  error: unknown;
+};
+
+type Aggregation = "daily" | "monthly";
+
+export interface PolymuffinData {
+  datasets: ReturnType<typeof useGlobalFilters>["datasets"];
+  keywords: string[];
+  gdelt: {
+    enabled: boolean;
+    series: GdeltSeriesPoint[];
+    events: GdeltEvent[];
+    insights?: GdeltInsights;
+    aggregation: Aggregation;
+    loading: boolean;
+    error: string | null;
+    activeDate: string | null;
+    setActiveDate: (value: string | null) => void;
+  };
+  poly: {
+    enabled: boolean;
+    markets: PolyMarket[];
+    loading: boolean;
+    error: string | null;
+  };
+  activity: {
+    datasets: DatasetStatusEntry[];
+    recentQueries: RecentQueryEntry[];
+  };
+  kpis: {
+    totalEvents?: number;
+    avgTone?: number;
+    avgImpact?: number;
+    topPair?: string;
+  };
+  refresh: () => void;
+  isFetchingAny: boolean;
+  combinedError: string | null;
+  openEvent: (event: GdeltEvent) => void;
+  openMarket: (id: string) => void;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
+
+const toRecordArray = (value: unknown): Record<string, unknown>[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is Record<string, unknown> => isRecord(item));
+};
+
+const toNumber = (value: unknown): number | undefined => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  return undefined;
+};
+
+const extractGdeltItems = (payload: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(payload)) {
+    return toRecordArray(payload);
+  }
+
+  if (!isRecord(payload)) {
+    return [];
+  }
+
+  if (Array.isArray(payload.data)) {
+    return toRecordArray(payload.data);
+  }
+
+  if (Array.isArray(payload.results)) {
+    return toRecordArray(payload.results);
+  }
+
+  if (Array.isArray(payload.series)) {
+    return toRecordArray(payload.series);
+  }
+
+  if (Array.isArray(payload.events)) {
+    return toRecordArray(payload.events);
+  }
+
+  return [];
+};
+
+const toSeriesPoint = (record: Record<string, unknown>): GdeltSeriesPoint => {
+  const dateCandidate =
+    record.DayDate ?? record.SQLDATE ?? record.date ?? record.day ?? record.timestamp ?? "";
+
+  const point: GdeltSeriesPoint = {
+    date: normalizeGdeltDate(dateCandidate),
+  };
+
+  const conflictCandidate = record.conflict_events ?? record.total_events ?? record.count ?? record.value;
+  const sentimentCandidate = record.avg_sentiment ?? record.average_sentiment ?? record.sentiment ?? record.avgTone;
+  const impactCandidate = record.avg_impact ?? record.average_impact ?? record.impact;
+  const interactionCandidate = record.interaction_count ?? record.interactions ?? record.total_interactions;
+  const coverageCandidate = record.relative_coverage ?? record.coverage ?? record.relative ?? record.relativeCoverage;
+
+  const conflictEvents = toNumber(conflictCandidate);
+  const avgSentiment = toNumber(sentimentCandidate);
+  const avgImpact = toNumber(impactCandidate);
+  const interactionCount = toNumber(interactionCandidate);
+  const relativeCoverage = toNumber(coverageCandidate);
+
+  if (conflictEvents !== undefined) {
+    point.conflict_events = conflictEvents;
+  }
+
+  if (avgSentiment !== undefined) {
+    point.avg_sentiment = avgSentiment;
+  }
+
+  if (avgImpact !== undefined) {
+    point.avg_impact = avgImpact;
+  }
+
+  if (interactionCount !== undefined) {
+    point.interaction_count = interactionCount;
+  }
+
+  if (relativeCoverage !== undefined) {
+    point.relative_coverage = relativeCoverage;
+  }
+
+  return point;
+};
+
+const toEvent = (record: Record<string, unknown>): GdeltEvent => {
+  const base: GdeltEvent = {
+    ...record,
+    SQLDATE: (record.SQLDATE ?? record.DayDate ?? record.date ?? "") as string | number,
+    SOURCEURL: typeof record.SOURCEURL === "string" ? record.SOURCEURL : "",
+    Actor1CountryCode:
+      typeof record.Actor1CountryCode === "string" ? record.Actor1CountryCode : undefined,
+    Actor2CountryCode:
+      typeof record.Actor2CountryCode === "string" ? record.Actor2CountryCode : undefined,
+    EventCode: typeof record.EventCode === "string" ? record.EventCode : undefined,
+    AvgTone: toNumber(record.AvgTone),
+  };
+
+  return base;
+};
+
+const average = (values: Array<number | undefined>): number | undefined => {
+  const filtered = values.filter((value): value is number => typeof value === "number");
+  if (filtered.length === 0) {
+    return undefined;
+  }
+  const total = filtered.reduce((sum, value) => sum + value, 0);
+  return total / filtered.length;
+};
+
+const topPairFromInsights = (insights?: GdeltInsights): string | undefined => {
+  if (!insights) {
+    return undefined;
+  }
+
+  const record = insights as Record<string, unknown>;
+
+  const direct = record.top_pair;
+  if (typeof direct === "string") {
+    return direct;
+  }
+
+  const pairsCandidate = record.top_pairs ?? record.actor_pairs ?? record.leading_pairs;
+  if (Array.isArray(pairsCandidate)) {
+    const first = pairsCandidate[0];
+    if (typeof first === "string") {
+      return first;
+    }
+    if (isRecord(first)) {
+      const label =
+        typeof first.label === "string"
+          ? first.label
+          : typeof first.pair === "string"
+            ? first.pair
+            : typeof first.name === "string"
+              ? first.name
+              : undefined;
+      if (label) {
+        return label;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const toIsoString = (timestamp?: number): string | undefined => {
+  if (!timestamp) {
+    return undefined;
+  }
+
+  if (timestamp <= 0) {
+    return undefined;
+  }
+
+  return new Date(timestamp).toISOString();
+};
+
+export function usePolymuffinData(): PolymuffinData {
+  const queryClient = useQueryClient();
+  const keywords = useGlobalFilters((state) => state.keywords);
+  const dateStart = useGlobalFilters((state) => state.dateStart);
+  const dateEnd = useGlobalFilters((state) => state.dateEnd);
+  const datasets = useGlobalFilters((state) => state.datasets);
+  const mode = useGdeltMode((state) => state.mode);
+  const modeParams = useGdeltMode((state) => state.params);
+  const openPanel = useSidePanel((state) => state.openPanel);
+
+  const [activeDate, setActiveDate] = useState<string | null>(null);
+
+  const contextParams = modeParams.context ?? { includeInsights: true, limit: 500 };
+  const countryParams = modeParams.country ?? { country: "" };
+  const bilateralParams = modeParams.bilateral ?? { country1: "", country2: "" };
+  const bbvaParams = modeParams.bbva ?? ({ actor1: "", actor2: "", includeTotal: false } as const);
+
+  const contextQuery = useGdeltContext(
+    mode === "context" && datasets.gdelt
+      ? {
+          includeInsights: contextParams.includeInsights,
+          limit: contextParams.limit,
+        }
+      : {
+          dateStart: "",
+          dateEnd: "",
+        },
+  );
+
+  const countryQuery = useGdeltCountry(
+    mode === "country" && datasets.gdelt
+      ? {
+          country: countryParams.country,
+          dateStart,
+          dateEnd,
+        }
+      : {
+          country: "",
+          dateStart: "",
+          dateEnd: "",
+        },
+  );
+
+  const bilateralQuery = useGdeltBilateral(
+    mode === "bilateral" && datasets.gdelt
+      ? {
+          country1: bilateralParams.country1,
+          country2: bilateralParams.country2,
+          dateStart,
+          dateEnd,
+        }
+      : {
+          country1: "",
+          country2: "",
+          dateStart: "",
+          dateEnd: "",
+        },
+  );
+
+  const bbvaQuery = useGdeltBBVA(
+    mode === "bbva" && datasets.gdelt
+      ? {
+          actor1: bbvaParams.actor1,
+          actor2: bbvaParams.actor2,
+          dateStart,
+          dateEnd,
+          includeTotal: bbvaParams.includeTotal,
+          cameoCodes: bbvaParams.cameoCodes,
+        }
+      : {
+          actor1: "",
+          actor2: "",
+          dateStart: "",
+          dateEnd: "",
+        },
+  );
+
+  const polyQuery = usePolySearch(
+    datasets.poly
+      ? {
+          q: keywords.length > 0 ? keywords.join(" ") : undefined,
+          active: true,
+          sort: "volume24h",
+        }
+      : { enabled: false },
+  );
+
+  const activeGdeltState: QueryState = useMemo(() => {
+    if (!datasets.gdelt) {
+      return { dataUpdatedAt: 0, isError: false, isLoading: false, isFetching: false, error: null };
+    }
+
+    switch (mode) {
+      case "country":
+        return {
+          dataUpdatedAt: countryQuery.dataUpdatedAt,
+          isError: countryQuery.isError,
+          isLoading: countryQuery.isLoading,
+          isFetching: countryQuery.isFetching,
+          error: countryQuery.error,
+        };
+      case "bilateral":
+        return {
+          dataUpdatedAt: bilateralQuery.dataUpdatedAt,
+          isError: bilateralQuery.isError,
+          isLoading: bilateralQuery.isLoading,
+          isFetching: bilateralQuery.isFetching,
+          error: bilateralQuery.error,
+        };
+      case "bbva":
+        return {
+          dataUpdatedAt: bbvaQuery.dataUpdatedAt,
+          isError: bbvaQuery.isError,
+          isLoading: bbvaQuery.isLoading,
+          isFetching: bbvaQuery.isFetching,
+          error: bbvaQuery.error,
+        };
+      default:
+        return {
+          dataUpdatedAt: contextQuery.dataUpdatedAt,
+          isError: contextQuery.isError,
+          isLoading: contextQuery.isLoading,
+          isFetching: contextQuery.isFetching,
+          error: contextQuery.error,
+        };
+    }
+  }, [
+    datasets.gdelt,
+    mode,
+    contextQuery.dataUpdatedAt,
+    contextQuery.isError,
+    contextQuery.isLoading,
+    contextQuery.isFetching,
+    contextQuery.error,
+    countryQuery.dataUpdatedAt,
+    countryQuery.isError,
+    countryQuery.isLoading,
+    countryQuery.isFetching,
+    countryQuery.error,
+    bilateralQuery.dataUpdatedAt,
+    bilateralQuery.isError,
+    bilateralQuery.isLoading,
+    bilateralQuery.isFetching,
+    bilateralQuery.error,
+    bbvaQuery.dataUpdatedAt,
+    bbvaQuery.isError,
+    bbvaQuery.isLoading,
+    bbvaQuery.isFetching,
+    bbvaQuery.error,
+  ]);
+
+  const activeGdeltData = useMemo(() => {
+    if (!datasets.gdelt) {
+      return { series: [] as GdeltSeriesPoint[], events: [] as GdeltEvent[], aggregation: "daily" as Aggregation };
+    }
+
+    if (mode === "context") {
+      return {
+        series: contextQuery.data?.series ?? [],
+        events: contextQuery.data?.events ?? [],
+        insights: contextQuery.data?.insights,
+        aggregation: "daily" as Aggregation,
+      };
+    }
+
+    const rawData =
+      mode === "country"
+        ? countryQuery.data
+        : mode === "bilateral"
+          ? bilateralQuery.data
+          : bbvaQuery.data;
+
+    const items = extractGdeltItems(rawData);
+    const series = items.map(toSeriesPoint);
+    const events = items.map(toEvent);
+
+    let insights: GdeltInsights | undefined;
+    let aggregation: Aggregation = "daily";
+
+    if (isRecord(rawData)) {
+      const rawInsights = rawData["insights"];
+      if (rawInsights && typeof rawInsights === "object") {
+        insights = rawInsights as GdeltInsights;
+      }
+
+      const aggregationCandidate = rawData["aggregation"] ?? rawData["granularity"] ?? rawData["time_unit"];
+      if (typeof aggregationCandidate === "string" && aggregationCandidate.toLowerCase().includes("month")) {
+        aggregation = "monthly";
+      }
+    }
+
+    return { series, events, insights, aggregation };
+  }, [
+    datasets.gdelt,
+    mode,
+    contextQuery.data,
+    countryQuery.data,
+    bilateralQuery.data,
+    bbvaQuery.data,
+  ]);
+
+  const gdeltSeries = activeGdeltData.series;
+  const gdeltEvents = activeGdeltData.events;
+  const gdeltInsights = activeGdeltData.insights;
+  const gdeltAggregation = activeGdeltData.aggregation;
+
+  const gdeltLoading = datasets.gdelt && (activeGdeltState.isLoading || activeGdeltState.isFetching);
+  const gdeltError =
+    datasets.gdelt && activeGdeltState.isError
+      ? activeGdeltState.error instanceof Error
+        ? activeGdeltState.error.message
+        : "Unknown error"
+      : null;
+
+  const markets = datasets.poly ? polyQuery.data?.markets ?? [] : [];
+  const polyLoading = datasets.poly && (polyQuery.isLoading || polyQuery.isFetching);
+  const polyError =
+    datasets.poly && polyQuery.isError
+      ? polyQuery.error instanceof Error
+        ? polyQuery.error.message
+        : "Unknown error"
+      : null;
+
+  const kpiValues = useMemo(
+    () => {
+      if (!datasets.gdelt) {
+        return {
+          totalEvents: undefined,
+          avgTone: undefined,
+          avgImpact: undefined,
+          topPair: undefined,
+        };
+      }
+
+      const totalEventsFromInsights =
+        typeof gdeltInsights?.total_events === "number" ? gdeltInsights.total_events : undefined;
+      const totalEventsFromSeries = gdeltSeries.reduce((sum, point) => sum + (point.conflict_events ?? 0), 0);
+      const totalEvents = totalEventsFromInsights ?? (totalEventsFromSeries > 0 ? totalEventsFromSeries : undefined);
+
+      const avgToneFromInsights =
+        gdeltInsights &&
+        typeof gdeltInsights.sentiment_analysis === "object" &&
+        gdeltInsights.sentiment_analysis !== null &&
+        typeof gdeltInsights.sentiment_analysis.avg_tone === "number"
+          ? gdeltInsights.sentiment_analysis.avg_tone
+          : undefined;
+
+      const avgTone = avgToneFromInsights ?? average(gdeltSeries.map((point) => point.avg_sentiment));
+      const avgImpact = average(gdeltSeries.map((point) => point.avg_impact));
+      const topPair = topPairFromInsights(gdeltInsights);
+
+      return { totalEvents, avgTone, avgImpact, topPair };
+    },
+    [datasets.gdelt, gdeltInsights, gdeltSeries],
+  );
+
+  const datasetStatuses = useMemo<DatasetStatusEntry[]>(
+    () => [
+      {
+        id: "gdelt",
+        label: "GDELT",
+        lastFetched: toIsoString(activeGdeltState.dataUpdatedAt),
+        status: !datasets.gdelt
+          ? "red"
+          : gdeltError
+            ? "red"
+            : activeGdeltState.isFetching
+              ? "yellow"
+              : "green",
+        fallback: gdeltAggregation === "monthly" ? "Monthly aggregation fallback" : null,
+        enabled: datasets.gdelt,
+      },
+      {
+        id: "poly",
+        label: "Polymarket",
+        lastFetched: toIsoString(polyQuery.dataUpdatedAt),
+        status: !datasets.poly
+          ? "red"
+          : polyError
+            ? "red"
+            : polyQuery.isFetching
+              ? "yellow"
+              : "green",
+        fallback: null,
+        enabled: datasets.poly,
+      },
+      {
+        id: "twitter",
+        label: "Twitter",
+        lastFetched: undefined,
+        status: datasets.twitter ? "yellow" : "red",
+        fallback: !datasets.twitter ? "Disabled" : "Awaiting integration",
+        enabled: datasets.twitter,
+      },
+    ],
+    [
+      activeGdeltState.dataUpdatedAt,
+      activeGdeltState.isFetching,
+      datasets.gdelt,
+      datasets.poly,
+      datasets.twitter,
+      gdeltAggregation,
+      gdeltError,
+      polyError,
+      polyQuery.dataUpdatedAt,
+      polyQuery.isFetching,
+    ],
+  );
+
+  const recentQueries = useMemo<RecentQueryEntry[]>(
+    () => {
+      const entries: RecentQueryEntry[] = [];
+      if (keywords.length === 0) {
+        return entries;
+      }
+
+      if (datasets.gdelt) {
+        entries.push({
+          query: keywords.join(", "),
+          timestamp: toIsoString(activeGdeltState.dataUpdatedAt) ?? new Date().toISOString(),
+          dataset: `GDELT (${mode.toUpperCase()})`,
+        });
+      }
+
+      if (datasets.poly) {
+        entries.push({
+          query: keywords.join(" "),
+          timestamp: toIsoString(polyQuery.dataUpdatedAt) ?? new Date().toISOString(),
+          dataset: "Polymarket",
+        });
+      }
+
+      return entries;
+    },
+    [
+      activeGdeltState.dataUpdatedAt,
+      datasets.gdelt,
+      datasets.poly,
+      keywords,
+      mode,
+      polyQuery.dataUpdatedAt,
+    ],
+  );
+
+  const refresh = useCallback(() => {
+    const prefixes: string[] = [];
+
+    if (datasets.poly) {
+      prefixes.push("poly");
+    }
+
+    if (datasets.gdelt) {
+      prefixes.push("gdelt");
+    }
+
+    prefixes.forEach((prefix) => {
+      queryClient.invalidateQueries({ queryKey: [prefix] });
+      queryClient.refetchQueries({ queryKey: [prefix], type: "active" });
+    });
+  }, [datasets.gdelt, datasets.poly, queryClient]);
+
+  const combinedError = gdeltError ?? polyError;
+
+  const openEvent = useCallback(
+    (event: GdeltEvent) => {
+      openPanel("event", {
+        json: event,
+        title: typeof event.SOURCEURL === "string" ? event.SOURCEURL : "Event details",
+        url: typeof event.SOURCEURL === "string" ? event.SOURCEURL : undefined,
+      });
+    },
+    [openPanel],
+  );
+
+  const openMarket = useCallback(
+    (id: string) => {
+      openPanel("market", { id });
+    },
+    [openPanel],
+  );
+
+  return {
+    datasets,
+    keywords,
+    gdelt: {
+      enabled: datasets.gdelt,
+      series: gdeltSeries,
+      events: gdeltEvents,
+      insights: gdeltInsights,
+      aggregation: gdeltAggregation,
+      loading: Boolean(gdeltLoading),
+      error: gdeltError,
+      activeDate,
+      setActiveDate,
+    },
+    poly: {
+      enabled: datasets.poly,
+      markets,
+      loading: Boolean(polyLoading),
+      error: polyError,
+    },
+    activity: {
+      datasets: datasetStatuses,
+      recentQueries,
+    },
+    kpis: kpiValues,
+    refresh,
+    isFetchingAny: Boolean(activeGdeltState.isFetching || polyQuery.isFetching),
+    combinedError,
+    openEvent,
+    openMarket,
+  };
+}

--- a/src/features/polymuffin/hooks/useViewportScale.ts
+++ b/src/features/polymuffin/hooks/useViewportScale.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useState } from "react";
+
+export function useViewportScale(baseW = 1920, baseH = 1080) {
+  const calc = useCallback(
+    () => Math.min(window.innerWidth / baseW, window.innerHeight / baseH),
+    [baseW, baseH],
+  );
+  const [scale, setScale] = useState(1);
+
+  useEffect(() => {
+    const onResize = () => setScale(calc());
+    setScale(calc());
+
+    let t: ReturnType<typeof setTimeout> | undefined;
+    const handle = () => {
+      if (t) {
+        clearTimeout(t);
+      }
+      t = setTimeout(onResize, 100);
+    };
+
+    window.addEventListener("resize", handle);
+    return () => {
+      window.removeEventListener("resize", handle);
+      if (t) {
+        clearTimeout(t);
+      }
+    };
+  }, [calc]);
+
+  return scale;
+}

--- a/src/features/polymuffin/ui/layout/Canvas.tsx
+++ b/src/features/polymuffin/ui/layout/Canvas.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React from "react";
+
+import { useViewportScale } from "@/features/polymuffin/hooks/useViewportScale";
+import { BASE } from "@/features/polymuffin/constants/layout";
+
+export default function Canvas({ children }: { children: React.ReactNode }) {
+  const scale = useViewportScale(BASE.W, BASE.H);
+
+  return (
+    <div className="fixed inset-0 bg-[color:var(--bg)] text-[color:var(--fg)] overflow-hidden">
+      <div
+        className="mx-auto"
+        style={{
+          width: `${BASE.W * scale}px`,
+          height: `${BASE.H * scale}px`,
+        }}
+      >
+        <div
+          style={{
+            width: `${BASE.W}px`,
+            height: `${BASE.H}px`,
+            transform: `scale(${scale})`,
+            transformOrigin: "top left",
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/polymuffin/ui/layout/NavRail.tsx
+++ b/src/features/polymuffin/ui/layout/NavRail.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useMemo } from "react";
+import { Activity, BarChart2, Twitter } from "lucide-react";
+
+import { useGlobalFilters } from "@/stores/useGlobalFilters";
+import { cn } from "@/lib/utils";
+
+const DATASET_ICONS: Record<"gdelt" | "poly" | "twitter", React.ComponentType<{ className?: string }>> = {
+  gdelt: Activity,
+  poly: BarChart2,
+  twitter: Twitter,
+};
+
+const DATASET_LABELS: Record<"gdelt" | "poly" | "twitter", string> = {
+  gdelt: "GDELT",
+  poly: "Polymarket",
+  twitter: "Twitter",
+};
+
+export default function NavRail() {
+  const datasets = useGlobalFilters((state) => state.datasets);
+  const toggleDataset = useGlobalFilters((state) => state.toggleDataset);
+
+  const buttons = useMemo(
+    () =>
+      (Object.keys(datasets) as Array<keyof typeof datasets>).map((key) => ({
+        id: key,
+        enabled: datasets[key],
+        label: DATASET_LABELS[key],
+        Icon: DATASET_ICONS[key],
+      })),
+    [datasets],
+  );
+
+  return (
+    <nav className="card flex h-full flex-col items-center justify-between gap-4 px-3 py-6">
+      <div className="flex flex-col items-center gap-4">
+        <div className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--muted)]">Poly</div>
+        <div className="h-px w-8 bg-[color:var(--border)]" />
+        <div className="flex flex-col items-center gap-3">
+          {buttons.map(({ id, label, Icon, enabled }) => (
+            <button
+              key={id}
+              type="button"
+              onClick={() => toggleDataset(id)}
+              className={cn(
+                "flex h-12 w-12 items-center justify-center rounded-2xl border text-[color:var(--muted)] transition",
+                enabled
+                  ? "border-[color:var(--accent)]/60 bg-[color:var(--accent)]/15 text-[color:var(--fg)]"
+                  : "border-[color:var(--border)]/70 bg-transparent hover:border-[color:var(--accent)]/40 hover:text-[color:var(--fg)]",
+              )}
+              aria-pressed={enabled}
+              aria-label={label}
+              title={label}
+            >
+              <Icon className="h-5 w-5" />
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="text-center text-[10px] uppercase tracking-[0.28em] text-[color:var(--muted)]">
+        Toggle datasets
+      </div>
+    </nav>
+  );
+}

--- a/src/features/polymuffin/ui/layout/Topbar.tsx
+++ b/src/features/polymuffin/ui/layout/Topbar.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useMemo } from "react";
+import { RefreshCw } from "lucide-react";
+
+import SearchBar from "@/components/SearchBar";
+import { CUSTOM_PRESET_EVENT } from "@/components/search/events";
+import { Preset, useGlobalFilters } from "@/stores/useGlobalFilters";
+import { cn } from "@/lib/utils";
+
+const PRESETS: Preset[] = ["7D", "30D", "90D"];
+
+type TopbarProps = {
+  loading?: boolean;
+  onRefresh?: () => void;
+  error?: string | null;
+};
+
+export default function Topbar({ loading = false, onRefresh, error = null }: TopbarProps) {
+  const activePreset = useGlobalFilters((state) => state.activePreset);
+  const setPreset = useGlobalFilters((state) => state.setPreset);
+  const dateStart = useGlobalFilters((state) => state.dateStart);
+  const dateEnd = useGlobalFilters((state) => state.dateEnd);
+
+  const rangeLabel = useMemo(() => {
+    const pretty = (value: string) => {
+      if (value.length !== 8) {
+        return value;
+      }
+      return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
+    };
+    return `${pretty(dateStart)} → ${pretty(dateEnd)}`;
+  }, [dateStart, dateEnd]);
+
+  const triggerCustom = () => {
+    setPreset("CUSTOM");
+    document.dispatchEvent(new CustomEvent(CUSTOM_PRESET_EVENT));
+  };
+
+  return (
+    <div className="card flex h-full items-center gap-6 px-6 py-4">
+      <div className="flex flex-1 items-center gap-6">
+        <div className="flex flex-col gap-1">
+          <span className="text-xs uppercase tracking-[0.28em] text-[color:var(--muted)]">Active range</span>
+          <span className="text-sm font-semibold text-[color:var(--fg)]">{rangeLabel}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          {PRESETS.map((preset) => (
+            <button
+              key={preset}
+              type="button"
+              onClick={() => setPreset(preset)}
+              className={cn(
+                "rounded-full border px-3 py-1 text-xs font-semibold transition",
+                activePreset === preset
+                  ? "border-[color:var(--accent)]/60 bg-[color:var(--accent)]/20 text-[color:var(--fg)]"
+                  : "border-[color:var(--border)]/70 text-[color:var(--muted)] hover:border-[color:var(--accent)]/40 hover:text-[color:var(--fg)]",
+              )}
+            >
+              {preset}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={triggerCustom}
+            className={cn(
+              "rounded-full border px-3 py-1 text-xs font-semibold text-[color:var(--muted)] transition",
+              activePreset === "CUSTOM"
+                ? "border-[color:var(--accent)]/60 bg-[color:var(--accent)]/20 text-[color:var(--fg)]"
+                : "border-[color:var(--border)]/70 hover:border-[color:var(--accent)]/40 hover:text-[color:var(--fg)]",
+            )}
+          >
+            Custom
+          </button>
+        </div>
+      </div>
+      <div className="flex flex-1 items-center justify-end gap-3">
+        <button
+          type="button"
+          onClick={onRefresh}
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-[color:var(--border)]/70 text-[color:var(--muted)] transition hover:border-[color:var(--accent)]/50 hover:text-[color:var(--fg)]"
+        >
+          <RefreshCw className={cn("h-4 w-4", loading && "animate-spin")} />
+        </button>
+        <div className="w-[620px] max-w-full">
+          <SearchBar loading={loading} error={error} onRetry={onRefresh} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/polymuffin/ui/panels/ActiveMarketsPanel.tsx
+++ b/src/features/polymuffin/ui/panels/ActiveMarketsPanel.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import ActivityPanel from "@/components/system/ActivityPanel";
+import type { ComponentProps } from "react";
+
+type DatasetStatusEntry = NonNullable<ComponentProps<typeof ActivityPanel>["datasets"]>[number];
+type RecentQueryEntry = NonNullable<ComponentProps<typeof ActivityPanel>["recentQueries"]>[number];
+
+type ActiveMarketsPanelProps = {
+  datasets: DatasetStatusEntry[];
+  recentQueries: RecentQueryEntry[];
+  loading: boolean;
+  error: string | null;
+};
+
+export default function ActiveMarketsPanel({ datasets, recentQueries, loading, error }: ActiveMarketsPanelProps) {
+  return (
+    <div className="card flex h-full flex-col overflow-hidden">
+      <header className="flex items-center justify-between border-b border-[color:var(--border)]/60 px-5 py-3">
+        <div>
+          <h3 className="text-base font-semibold text-[color:var(--fg)]">Dataset activity</h3>
+          <p className="text-xs text-[color:var(--muted)]">Monitor sync health and recent lookups</p>
+        </div>
+      </header>
+      <div className="flex-1 overflow-hidden px-4 py-3">
+        <ActivityPanel datasets={datasets} recentQueries={recentQueries} isLoading={loading} error={error ?? undefined} />
+      </div>
+    </div>
+  );
+}

--- a/src/features/polymuffin/ui/panels/GdeltSummary.tsx
+++ b/src/features/polymuffin/ui/panels/GdeltSummary.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { InsightsPanel } from "@/components/gdelt/InsightsPanel";
+import type { GdeltInsights } from "@/types";
+
+interface GdeltSummaryProps {
+  insights?: GdeltInsights;
+  loading: boolean;
+  error: string | null;
+}
+
+export default function GdeltSummary({ insights, loading, error }: GdeltSummaryProps) {
+  return (
+    <div className="card flex h-full flex-col overflow-hidden">
+      <header className="flex items-center justify-between border-b border-[color:var(--border)]/60 px-5 py-3">
+        <div>
+          <h3 className="text-base font-semibold text-[color:var(--fg)]">Narrative summary</h3>
+          <p className="text-xs text-[color:var(--muted)]">Top actors, spikes and keyword matches</p>
+        </div>
+      </header>
+      <div className="flex-1 overflow-hidden px-4 py-3">
+        <InsightsPanel insights={insights} isLoading={loading} error={error ?? undefined} />
+      </div>
+    </div>
+  );
+}

--- a/src/features/polymuffin/ui/panels/KpiStrip.tsx
+++ b/src/features/polymuffin/ui/panels/KpiStrip.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useMemo } from "react";
+
+interface KpiStripProps {
+  totalEvents?: number;
+  avgTone?: number;
+  avgImpact?: number;
+  topPair?: string;
+  loading: boolean;
+  error: string | null;
+}
+
+export default function KpiStrip({ totalEvents, avgTone, avgImpact, topPair, loading, error }: KpiStripProps) {
+  const items = useMemo(
+    () => [
+      {
+        label: "Total events",
+        value: formatNumber(totalEvents, { maximumFractionDigits: 0 }),
+      },
+      {
+        label: "Avg tone",
+        value: formatNumber(avgTone, { maximumFractionDigits: 2, minimumFractionDigits: 2 }),
+      },
+      {
+        label: "Avg impact",
+        value: formatNumber(avgImpact, { maximumFractionDigits: 2, minimumFractionDigits: 2 }),
+      },
+      {
+        label: "Top pair",
+        value: topPair ?? "—",
+      },
+    ],
+    [avgImpact, avgTone, topPair, totalEvents],
+  );
+
+  if (error) {
+    return (
+      <div className="card flex h-full items-center justify-center text-sm text-[color:var(--accent-light)]">
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="card flex h-full flex-col justify-between px-5 py-4">
+      <header>
+        <h3 className="text-base font-semibold text-[color:var(--fg)]">Impact snapshot</h3>
+        <p className="text-xs text-[color:var(--muted)]">Key indicators from the active window</p>
+      </header>
+      <div className="grid grid-cols-2 gap-3 text-sm text-[color:var(--muted)]">
+        {items.map((item) => (
+          <div key={item.label} className="rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--panel)]/50 px-3 py-2">
+            <p className="text-[11px] uppercase tracking-[0.28em]">{item.label}</p>
+            <p className="mt-1 text-lg font-semibold text-[color:var(--fg)] tabular-nums">
+              {loading ? <span className="inline-block h-4 w-16 animate-pulse rounded-full bg-[color:var(--panel-strong)]" /> : item.value}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function formatNumber(value?: number, options?: Intl.NumberFormatOptions) {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return "—";
+  }
+
+  return value.toLocaleString(undefined, options);
+}

--- a/src/features/polymuffin/ui/panels/MarketsGrid.tsx
+++ b/src/features/polymuffin/ui/panels/MarketsGrid.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import type { PolyMarket } from "@/types";
+
+const PAGE_SIZE = 4;
+
+type MarketsGridProps = {
+  markets: PolyMarket[];
+  enabled: boolean;
+  loading: boolean;
+  error: string | null;
+  onOpenMarket?: (id: string) => void;
+};
+
+export default function MarketsGrid({ markets, enabled, loading, error, onOpenMarket }: MarketsGridProps) {
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    setPage(1);
+  }, [markets]);
+
+  const pages = Math.max(1, Math.ceil((markets?.length ?? 0) / PAGE_SIZE));
+  const entries = useMemo(() => {
+    if (!enabled) {
+      return [];
+    }
+    const start = (page - 1) * PAGE_SIZE;
+    return markets.slice(start, start + PAGE_SIZE);
+  }, [enabled, markets, page]);
+
+  if (!enabled) {
+    return (
+      <div className="card flex h-full items-center justify-center text-sm text-[color:var(--muted)]">
+        Enable Polymarket to browse active markets.
+      </div>
+    );
+  }
+
+  return (
+    <div className="card flex h-full flex-col">
+      <Header page={page} pages={pages} onPrev={() => setPage((p) => Math.max(1, p - 1))} onNext={() => setPage((p) => Math.min(pages, p + 1))} />
+      <div className="grid flex-1 grid-cols-2 gap-4 px-5 py-4">
+        {loading ? (
+          Array.from({ length: PAGE_SIZE }).map((_, index) => (
+            <div key={index} className="card h-full animate-pulse rounded-2xl bg-[color:var(--panel-strong)]/60" />
+          ))
+        ) : error ? (
+          <div className="col-span-2 flex items-center justify-center text-sm text-[color:var(--accent-light)]">{error}</div>
+        ) : entries.length === 0 ? (
+          <div className="col-span-2 flex items-center justify-center text-sm text-[color:var(--muted)]">No markets available.</div>
+        ) : (
+          entries.map((market) => (
+            <article key={market.id} className="card flex flex-col gap-3 rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--panel)]/60 p-4">
+              <header>
+                <p className="text-[11px] uppercase tracking-[0.28em] text-[color:var(--muted)]">{market.category ?? "Market"}</p>
+                <h4 className="mt-1 line-clamp-2 text-sm font-semibold text-[color:var(--fg)]">{market.title ?? "Untitled"}</h4>
+              </header>
+              <div className="flex gap-2 text-xs">
+                <Tag label="YES" value={market.priceYes} />
+                <Tag label="NO" value={market.priceNo} accent="var(--violet)" />
+              </div>
+              <dl className="grid grid-cols-2 gap-3 text-xs text-[color:var(--muted)]">
+                <div>
+                  <dt className="text-[10px] uppercase tracking-[0.28em]">Volume 24h</dt>
+                  <dd className="text-sm font-semibold text-[color:var(--fg)]">${formatNumber(market.volume24h)}</dd>
+                </div>
+                <div>
+                  <dt className="text-[10px] uppercase tracking-[0.28em]">Liquidity</dt>
+                  <dd className="text-sm font-semibold text-[color:var(--fg)]">${formatNumber(market.liquidity)}</dd>
+                </div>
+              </dl>
+              <footer className="mt-auto flex items-center justify-between text-xs text-[color:var(--muted)]">
+                <button
+                  type="button"
+                  onClick={() => market.id && onOpenMarket?.(market.id)}
+                  className="rounded-full border border-[color:var(--accent)]/60 px-3 py-1 text-xs font-semibold text-[color:var(--fg)] transition hover:bg-[color:var(--accent)]/20"
+                >
+                  Open details
+                </button>
+                {market.endDate ? <span>{formatDate(market.endDate)}</span> : null}
+              </footer>
+            </article>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Header({ page, pages, onPrev, onNext }: { page: number; pages: number; onPrev: () => void; onNext: () => void }) {
+  return (
+    <header className="flex items-center justify-between border-b border-[color:var(--border)]/60 px-5 py-3">
+      <h3 className="text-base font-semibold text-[color:var(--fg)]">Markets</h3>
+      <div className="flex items-center gap-2 text-xs text-[color:var(--muted)]">
+        <button
+          type="button"
+          onClick={onPrev}
+          className="flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--border)]/70 transition hover:border-[color:var(--accent)]/50 hover:text-[color:var(--fg)]"
+        >
+          ◀
+        </button>
+        <span className="w-14 text-center font-semibold text-[color:var(--fg)]">
+          {page}/{pages}
+        </span>
+        <button
+          type="button"
+          onClick={onNext}
+          className="flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--border)]/70 transition hover:border-[color:var(--accent)]/50 hover:text-[color:var(--fg)]"
+        >
+          ▶
+        </button>
+      </div>
+    </header>
+  );
+}
+
+function Tag({ label, value, accent }: { label: string; value?: number | null; accent?: string }) {
+  const display = value == null || Number.isNaN(value)
+    ? "—"
+    : `${(value * 100).toFixed(1)}%`;
+  return (
+    <span
+      className="rounded-full border border-[color:var(--border)]/70 px-3 py-1 font-semibold text-[color:var(--fg)]"
+      style={{ background: accent ? `${accent}33` : "var(--panel-strong)" }}
+    >
+      {label} {display}
+    </span>
+  );
+}
+
+function formatNumber(value?: number | null) {
+  if (value == null || Number.isNaN(value)) {
+    return "—";
+  }
+  if (Math.abs(value) >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`;
+  }
+  if (Math.abs(value) >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}K`;
+  }
+  return value.toLocaleString(undefined, { maximumFractionDigits: 0 });
+}
+
+function formatDate(value?: string | null) {
+  if (!value) {
+    return "—";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}

--- a/src/features/polymuffin/ui/panels/NewsList.tsx
+++ b/src/features/polymuffin/ui/panels/NewsList.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import type { GdeltEvent } from "@/types";
+
+const PAGE_SIZE = 6;
+
+type NewsListProps = {
+  events: GdeltEvent[];
+  enabled: boolean;
+  loading: boolean;
+  error: string | null;
+  onOpenEvent?: (event: GdeltEvent) => void;
+};
+
+export default function NewsList({ events, enabled, loading, error, onOpenEvent }: NewsListProps) {
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    setPage(1);
+  }, [events]);
+
+  const pages = Math.max(1, Math.ceil((events?.length ?? 0) / PAGE_SIZE));
+  const entries = useMemo(() => {
+    if (!enabled) {
+      return [];
+    }
+    const start = (page - 1) * PAGE_SIZE;
+    return events.slice(start, start + PAGE_SIZE);
+  }, [enabled, events, page]);
+
+  if (!enabled) {
+    return (
+      <div className="card flex h-full items-center justify-center text-sm text-[color:var(--muted)]">
+        Enable the GDELT dataset to browse event context.
+      </div>
+    );
+  }
+
+  return (
+    <div className="card flex h-full flex-col">
+      <Header page={page} pages={pages} onPrev={() => setPage((p) => Math.max(1, p - 1))} onNext={() => setPage((p) => Math.min(pages, p + 1))} />
+      <div className="flex-1 px-4 py-3">
+        {loading ? (
+          <div className="space-y-3">
+            {Array.from({ length: PAGE_SIZE }).map((_, index) => (
+              <div key={index} className="h-14 w-full animate-pulse rounded-2xl bg-[color:var(--panel-strong)]/60" />
+            ))}
+          </div>
+        ) : error ? (
+          <div className="flex h-full items-center justify-center text-sm text-[color:var(--accent-light)]">{error}</div>
+        ) : entries.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-sm text-[color:var(--muted)]">No events in the selected range.</div>
+        ) : (
+          <ul className="space-y-3 text-sm text-[color:var(--muted)]">
+            {entries.map((event, index) => (
+              <li key={`${event.SOURCEURL ?? event.SQLDATE}-${index}`} className="rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--panel)]/50 px-4 py-3">
+                <button
+                  type="button"
+                  onClick={() => onOpenEvent?.(event)}
+                  className="text-left"
+                >
+                  <p className="text-xs uppercase tracking-[0.28em]">{event.Actor1CountryCode ?? ""}</p>
+                  <p className="mt-1 line-clamp-2 text-sm font-semibold text-[color:var(--fg)]">{event.SOURCEURL ?? "Event"}</p>
+                  <p className="mt-1 text-xs text-[color:var(--muted)]">{formatDate(event.SQLDATE)}</p>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Header({ page, pages, onPrev, onNext }: { page: number; pages: number; onPrev: () => void; onNext: () => void }) {
+  return (
+    <header className="flex items-center justify-between border-b border-[color:var(--border)]/60 px-5 py-3">
+      <h3 className="text-base font-semibold text-[color:var(--fg)]">Event digest</h3>
+      <div className="flex items-center gap-2 text-xs text-[color:var(--muted)]">
+        <button
+          type="button"
+          onClick={onPrev}
+          className="flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--border)]/70 transition hover:border-[color:var(--accent)]/50 hover:text-[color:var(--fg)]"
+        >
+          ◀
+        </button>
+        <span className="w-14 text-center font-semibold text-[color:var(--fg)]">
+          {page}/{pages}
+        </span>
+        <button
+          type="button"
+          onClick={onNext}
+          className="flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--border)]/70 transition hover:border-[color:var(--accent)]/50 hover:text-[color:var(--fg)]"
+        >
+          ▶
+        </button>
+      </div>
+    </header>
+  );
+}
+
+function formatDate(value: string | number | undefined) {
+  if (value == null) {
+    return "—";
+  }
+  const date = new Date(String(value));
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}

--- a/src/features/polymuffin/ui/panels/OddsDistribution.tsx
+++ b/src/features/polymuffin/ui/panels/OddsDistribution.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useMemo } from "react";
+
+import type { PolyMarket } from "@/types";
+
+interface OddsDistributionProps {
+  markets: PolyMarket[];
+  enabled: boolean;
+  loading: boolean;
+  error: string | null;
+}
+
+export default function OddsDistribution({ markets, enabled, loading, error }: OddsDistributionProps) {
+  const stats = useMemo(() => {
+    if (!enabled || markets.length === 0) {
+      return null;
+    }
+
+    const safeMarkets = markets.slice(0, 20);
+    const yesAverage = average(safeMarkets.map((market) => market.priceYes ?? 0));
+    const noAverage = average(safeMarkets.map((market) => market.priceNo ?? 0));
+    const bullish = safeMarkets.filter((market) => (market.priceYes ?? 0) >= 0.6).length;
+    const bearish = safeMarkets.filter((market) => (market.priceYes ?? 0) <= 0.4).length;
+
+    return {
+      yesAverage,
+      noAverage,
+      bullish,
+      bearish,
+      total: safeMarkets.length,
+    };
+  }, [enabled, markets]);
+
+  if (!enabled) {
+    return (
+      <div className="card flex h-full items-center justify-center text-sm text-[color:var(--muted)]">
+        Enable Polymarket to unlock odds analytics.
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="card flex h-full items-center justify-center text-sm text-[color:var(--accent-light)]">{error}</div>
+    );
+  }
+
+  return (
+    <div className="card flex h-full flex-col justify-between px-5 py-4">
+      <header>
+        <h3 className="text-base font-semibold text-[color:var(--fg)]">Odds distribution</h3>
+        <p className="text-xs text-[color:var(--muted)]">Probability snapshot across top markets</p>
+      </header>
+      {loading || !stats ? (
+        <div className="mt-4 space-y-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="h-3 w-full animate-pulse rounded-full bg-[color:var(--panel-strong)]" />
+          ))}
+        </div>
+      ) : (
+        <div className="mt-4 space-y-4 text-sm text-[color:var(--muted)]">
+          <Progress label="YES avg" value={stats.yesAverage * 100} accent="var(--accent)" />
+          <Progress label="NO avg" value={stats.noAverage * 100} accent="var(--violet)" />
+          <div className="flex items-center justify-between rounded-2xl border border-[color:var(--border)]/70 bg-[color:var(--panel)]/50 px-4 py-3">
+            <div>
+              <p className="text-[11px] uppercase tracking-[0.28em]">Confidence split</p>
+              <p className="text-lg font-semibold text-[color:var(--fg)]">
+                {stats.bullish}/{stats.total} bullish · {stats.bearish}/{stats.total} bearish
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function average(values: number[]) {
+  if (values.length === 0) {
+    return 0;
+  }
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return total / values.length;
+}
+
+function Progress({ label, value, accent }: { label: string; value: number; accent: string }) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.28em]">
+        <span>{label}</span>
+        <span className="text-sm font-semibold text-[color:var(--fg)]">{value.toFixed(1)}%</span>
+      </div>
+      <div className="h-3 w-full rounded-full bg-[color:var(--panel)]">
+        <div
+          className="h-full rounded-full"
+          style={{ width: `${Math.min(100, Math.max(0, value))}%`, background: accent }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/polymuffin/ui/panels/TimeseriesPanel.tsx
+++ b/src/features/polymuffin/ui/panels/TimeseriesPanel.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { GdeltChart } from "@/components/gdelt/GdeltChart";
+import type { GdeltSeriesPoint } from "@/types";
+
+interface TimeseriesPanelProps {
+  enabled: boolean;
+  series: GdeltSeriesPoint[];
+  aggregation: "daily" | "monthly";
+  loading: boolean;
+  error: string | null;
+  onDateClick?: (iso: string) => void;
+  onResetDate?: () => void;
+}
+
+export default function TimeseriesPanel({
+  enabled,
+  series,
+  aggregation,
+  loading,
+  error,
+  onDateClick,
+}: TimeseriesPanelProps) {
+  if (!enabled) {
+    return (
+      <div className="card flex h-full items-center justify-center text-sm text-[color:var(--muted)]">
+        Enable the GDELT dataset to view the temporal distribution.
+      </div>
+    );
+  }
+
+  return (
+    <div className="card flex h-full flex-col overflow-hidden">
+      <header className="flex items-center justify-between border-b border-[color:var(--border)]/60 px-5 py-3">
+        <div>
+          <h3 className="text-base font-semibold text-[color:var(--fg)]">Conflict activity</h3>
+          <p className="text-xs text-[color:var(--muted)]">{aggregation === "monthly" ? "Monthly" : "Daily"} aggregation</p>
+        </div>
+      </header>
+      <div className="flex-1 px-2 py-2">
+        <GdeltChart
+          series={series}
+          aggregation={aggregation}
+          onDateClick={onDateClick}
+          isLoading={loading}
+          error={error ?? undefined}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a viewport-scaled canvas and restructure the main page into a fixed 1920×1080 dashboard grid with internal pagination panels
- centralize data gathering in a new polymuffin hook and provide compact panel components for charts, markets, news, and system activity
- refresh global styling and app layout to support the glassmorphic desktop experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfa6fb65b883288e5fb168779d3be0