### PR TITLE
Handle temporal GDELT insight shapes

### DIFF
--- a/docs/gdelt/temporal-insight-shapes.md
+++ b/docs/gdelt/temporal-insight-shapes.md
@@ -1,0 +1,80 @@
+# GDELT context temporal insight payloads
+
+The `/api/gdelt?action=context&…` proxy can surface `insights.temporal_distribution` or `insights.timeline` in a few different shapes. The samples below were captured while querying the Poly GDELT proxy and trimmed for brevity so we can document how the structures differ.
+
+## 1. Flat array payload
+
+`GET /api/gdelt?action=context&date_start=20240101&date_end=20240107&include_insights=true&limit=25`
+
+```json
+{
+  "insights": {
+    "temporal_distribution": [
+      { "date": "2024-01-01", "count": 96 },
+      { "date": "2024-01-02", "count": 104 },
+      { "date": "2024-01-03", "count": 88 }
+    ]
+  }
+}
+```
+
+## 2. Keyed object payload
+
+`GET /api/gdelt?action=context&keywords=energy&date_start=20240101&date_end=20240107&include_insights=true`
+
+```json
+{
+  "insights": {
+    "temporal_distribution": {
+      "2024-01-01": { "date": "2024-01-01", "count": 54 },
+      "2024-01-02": { "date": "2024-01-02", "count": 61 },
+      "2024-01-03": { "date": "2024-01-03", "count": 59 }
+    }
+  }
+}
+```
+
+## 3. Nested series payload
+
+`GET /api/gdelt?action=context&keywords=ai&date_start=20231201&date_end=20240115&include_insights=true`
+
+```json
+{
+  "insights": {
+    "temporal_distribution": {
+      "series": [
+        {
+          "label": "Relative coverage",
+          "timeline": [
+            { "date": "2023-12-01", "value": 0.18 },
+            { "date": "2023-12-02", "value": 0.21 }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+## 4. Timeline fallback payload
+
+`GET /api/gdelt?action=context&keywords=geopolitics&date_start=20240201&date_end=20240215&include_insights=true`
+
+```json
+{
+  "insights": {
+    "temporal_distribution": [],
+    "timeline": {
+      "series": [
+        {
+          "name": "Events",
+          "data": [
+            { "label": "2024-02-01", "total": 120 },
+            { "label": "2024-02-02", "total": 134 }
+          ]
+        }
+      ]
+    }
+  }
+}
+```

--- a/src/components/gdelt/InsightsPanel.tsx
+++ b/src/components/gdelt/InsightsPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from "recharts";
 
 import type { GdeltInsights } from "@/types";
+import { TemporalEntry, toTemporalEntries } from "./temporal";
 
 interface InsightsPanelProps {
   insights?: GdeltInsights | null;
@@ -21,11 +22,6 @@ interface InsightsPanelProps {
 interface KeywordEntry {
   keyword: string;
   count: number;
-}
-
-interface TemporalEntry {
-  label: string;
-  value: number;
 }
 
 interface ActorEntry {
@@ -41,25 +37,6 @@ const toKeywordEntries = (matches?: Record<string, number>): KeywordEntry[] => {
     .filter((entry) => Number.isFinite(entry.count))
     .sort((a, b) => b.count - a.count)
     .slice(0, 5);
-};
-
-const toTemporalEntries = (insights?: GdeltInsights): TemporalEntry[] => {
-  const raw = (insights?.temporal_distribution ?? insights?.timeline ?? []) as unknown[];
-
-  return raw
-    .map((item) => {
-      if (typeof item === "object" && item !== null) {
-        const record = item as Record<string, unknown>;
-        const label = typeof record.date === "string" ? record.date : typeof record.label === "string" ? record.label : null;
-        const valueCandidate = record.count ?? record.value ?? record.total;
-        const value = typeof valueCandidate === "number" ? valueCandidate : Number(valueCandidate);
-        if (label && Number.isFinite(value)) {
-          return { label, value };
-        }
-      }
-      return null;
-    })
-    .filter((entry): entry is TemporalEntry => Boolean(entry));
 };
 
 const toActorEntries = (insights?: GdeltInsights): ActorEntry[] => {

--- a/src/components/gdelt/__tests__/InsightsPanel.test.tsx
+++ b/src/components/gdelt/__tests__/InsightsPanel.test.tsx
@@ -1,0 +1,60 @@
+import { toTemporalEntries } from "../temporal";
+import type { GdeltInsights } from "@/types";
+
+describe("toTemporalEntries", () => {
+  it("normalizes array shaped temporal insights", () => {
+    const insights: GdeltInsights = {
+      temporal_distribution: [
+        { date: "2024-01-01", count: 4 },
+        { label: "2024-01-02", value: "6" },
+      ],
+    };
+
+    expect(toTemporalEntries(insights)).toEqual([
+      { label: "2024-01-01", value: 4 },
+      { label: "2024-01-02", value: 6 },
+    ]);
+  });
+
+  it("normalizes object shaped temporal insights", () => {
+    const insights: GdeltInsights = {
+      temporal_distribution: {
+        series: [
+          {
+            label: "Events",
+            timeline: [
+              { date: "2024-01-03", count: 8 },
+              { label: "2024-01-04", value: "9" },
+            ],
+          },
+        ],
+      },
+    };
+
+    expect(toTemporalEntries(insights)).toEqual([
+      { label: "2024-01-03", value: 8 },
+      { label: "2024-01-04", value: 9 },
+    ]);
+  });
+
+  it("falls back to timeline payloads when temporal distribution is empty", () => {
+    const insights: GdeltInsights = {
+      temporal_distribution: [],
+      timeline: {
+        series: [
+          {
+            data: [
+              { name: "2024-02-01", total: 12 },
+              { label: "2024-02-02", total: "15" },
+            ],
+          },
+        ],
+      },
+    };
+
+    expect(toTemporalEntries(insights)).toEqual([
+      { label: "2024-02-01", value: 12 },
+      { label: "2024-02-02", value: 15 },
+    ]);
+  });
+});

--- a/src/components/gdelt/temporal.ts
+++ b/src/components/gdelt/temporal.ts
@@ -1,0 +1,81 @@
+import type { GdeltInsights } from "@/types";
+
+export interface TemporalEntry {
+  label: string;
+  value: number;
+}
+
+const extractTemporalCandidates = (input: unknown): unknown[] => {
+  if (Array.isArray(input)) {
+    return input;
+  }
+
+  if (typeof input === "object" && input !== null) {
+    const record = input as Record<string, unknown>;
+
+    if ("series" in record) {
+      const series = record.series;
+      const flattenedSeries = (Array.isArray(series) ? series : [series])
+        .filter(Boolean)
+        .flatMap((item) => extractTemporalCandidates(item));
+
+      if (flattenedSeries.length > 0) {
+        return flattenedSeries;
+      }
+    }
+
+    if ("timeline" in record) {
+      const timelineCandidates = extractTemporalCandidates(record.timeline);
+      if (timelineCandidates.length > 0) {
+        return timelineCandidates;
+      }
+    }
+
+    if ("data" in record) {
+      const dataCandidates = extractTemporalCandidates(record.data);
+      if (dataCandidates.length > 0) {
+        return dataCandidates;
+      }
+    }
+
+    return Object.values(record);
+  }
+
+  return [];
+};
+
+const mapTemporalEntries = (raw: unknown[]): TemporalEntry[] =>
+  raw
+    .map((item) => {
+      if (typeof item === "object" && item !== null) {
+        const record = item as Record<string, unknown>;
+        const label =
+          typeof record.date === "string"
+            ? record.date
+            : typeof record.label === "string"
+              ? record.label
+              : typeof record.name === "string"
+                ? record.name
+                : null;
+        const valueCandidate = record.count ?? record.value ?? record.total;
+        const value = typeof valueCandidate === "number" ? valueCandidate : Number(valueCandidate);
+        if (label && Number.isFinite(value)) {
+          return { label, value };
+        }
+      }
+      return null;
+    })
+    .filter((entry): entry is TemporalEntry => Boolean(entry));
+
+export const toTemporalEntries = (insights?: GdeltInsights): TemporalEntry[] => {
+  if (!insights) {
+    return [];
+  }
+
+  const primary = mapTemporalEntries(extractTemporalCandidates(insights.temporal_distribution));
+  if (primary.length > 0) {
+    return primary;
+  }
+
+  return mapTemporalEntries(extractTemporalCandidates(insights.timeline));
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,13 +35,55 @@ export interface GdeltContextApiResponse {
   [key: string]: unknown;
 }
 
+export interface GdeltTemporalDatum {
+  date?: string | null;
+  label?: string | null;
+  name?: string | null;
+  count?: number | string | null;
+  value?: number | string | null;
+  total?: number | string | null;
+  [key: string]: unknown;
+}
+
+export interface GdeltTemporalSeriesNode {
+  label?: string | null;
+  name?: string | null;
+  series?: Array<GdeltTemporalSeriesNode | GdeltTemporalDatum | null> | null;
+  timeline?: Array<GdeltTemporalSeriesNode | GdeltTemporalDatum | null> | GdeltTemporalSeriesNode | null;
+  data?: Array<GdeltTemporalSeriesNode | GdeltTemporalDatum | null> | GdeltTemporalSeriesNode | null;
+  [key: string]: unknown;
+}
+
+export type GdeltTemporalInsight =
+  | GdeltTemporalDatum[]
+  | Record<string, GdeltTemporalDatum | number | string | null>
+  | {
+      series?: Array<GdeltTemporalSeriesNode | GdeltTemporalDatum | null> | null;
+      timeline?:
+        | Array<GdeltTemporalSeriesNode | GdeltTemporalDatum | null>
+        | GdeltTemporalSeriesNode
+        | null;
+      data?: Array<GdeltTemporalSeriesNode | GdeltTemporalDatum | null> | GdeltTemporalSeriesNode | null;
+      [key: string]: unknown;
+    };
+
 export interface GdeltInsights {
   total_events?: number;
   keyword_matches?: Record<string, number>;
   sentiment_analysis?: {
     avg_tone?: number;
   };
-  /* add from context insights */
+  temporal_distribution?: GdeltTemporalInsight | null;
+  timeline?: GdeltTemporalInsight | null;
+  spikes?: Array<string | { label?: string | null; date?: string | null; [key: string]: unknown }>;
+  top_actors?:
+    | Array<string | { name?: string | null; actor?: string | null; label?: string | null; count?: number | string | null }> 
+    | Record<string, number>
+    | null;
+  actor_counts?:
+    | Array<string | { name?: string | null; actor?: string | null; label?: string | null; count?: number | string | null }>
+    | Record<string, number>
+    | null;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- document representative /api/gdelt?action=context insight payloads so the different temporal shapes are captured
- add a dedicated transformer that normalizes temporal_distribution/timeline objects into chart-ready entries and wire it into InsightsPanel
- extend the GdeltInsights typings and add unit coverage to guard both array and object shaped temporal responses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfb27e848c832894d04942a019fa80