### PR TITLE
feat: replace nav rail title with logo

### DIFF
--- a/src/components/gdelt/InsightsPanel.tsx
+++ b/src/components/gdelt/InsightsPanel.tsx
@@ -11,7 +11,7 @@ import {
 } from "recharts";
 
 import type { GdeltInsights } from "@/types";
-import { TemporalEntry, toTemporalEntries } from "./temporal";
+import { toTemporalEntries } from "./temporal";
 
 interface InsightsPanelProps {
   insights?: GdeltInsights | null;

--- a/src/features/polymuffin/ui/layout/NavRail.tsx
+++ b/src/features/polymuffin/ui/layout/NavRail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useMemo } from "react";
 import { Activity, BarChart2, Twitter } from "lucide-react";
 
@@ -36,8 +37,15 @@ export default function NavRail() {
   return (
     <nav className="card flex h-full flex-col items-center justify-between gap-4 px-3 py-6">
       <div className="flex flex-col items-center gap-4">
-        <div className="text-[10px] font-semibold tracking-[0.18em] leading-3 text-[color:var(--muted)]">
-          Polymuffin
+        <div className="flex items-center justify-center">
+          <Image
+            src="/polymuffinpng.png"
+            alt="Polymuffin logo"
+            width={48}
+            height={48}
+            className="h-6 w-auto"
+            priority
+          />
         </div>
         <div className="h-px w-8 bg-[color:var(--border)]" />
         <div className="flex flex-col items-center gap-3">


### PR DESCRIPTION
## Summary
- replace the Polymuffin label in the navigation rail with the polymuffinpng.png logo
- remove an unused type import in the GDELT insights panel

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4e6bf084c8328b82b5b8197d347f9